### PR TITLE
feat: implement Spring Security with HTTP Basic authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ Project created for study and aims to be a REST api of a CRUD:
 * After creating the database, start the application
 * Include to VM Options: -Dspring.profiles.active=local
 * Url Swagger: http://localhost:8080/ecommerce/swagger-ui/index.html#/
+* O projeto usa Spring Security e é configurado na classe WebSecurityConfig
+  * Para realizar uma requisição autenticada, segue um exemplo para executar no PowerShell
+  * $headers = @{Authorization = "Basic " + [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes("usuario:senha"))}; Invoke-RestMethod -Uri "http://localhost:8080/ecommerce/customer" -Method Get -Headers $headers
 
 
 ### References

--- a/build.gradle
+++ b/build.gradle
@@ -20,16 +20,23 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.postgresql:postgresql:42.7.3'
-    compileOnly 'org.projectlombok:lombok:1.18.32'
-    implementation "org.springframework.boot:spring-boot-starter-data-jpa"
+
     implementation "org.springframework.boot:spring-boot-starter-web"
     implementation "org.springframework.boot:spring-boot-starter-validation"
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+    implementation "org.springframework.boot:spring-boot-starter-data-jpa"
+
+    implementation 'org.postgresql:postgresql:42.7.3'
     implementation 'org.flywaydb:flyway-mysql:9.11.0'
     implementation 'org.flywaydb:flyway-core:9.11.0'
     implementation 'com.mysql:mysql-connector-j:8.4.0'
+
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
+
     testImplementation "org.springframework.boot:spring-boot-starter-test"
+
+    compileOnly 'org.projectlombok:lombok:1.18.32'
     annotationProcessor 'org.projectlombok:lombok:1.18.32'
 }
 

--- a/src/main/java/br/com/ecommerce/config/PostgresConfig.java
+++ b/src/main/java/br/com/ecommerce/config/PostgresConfig.java
@@ -14,7 +14,6 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 import javax.sql.DataSource;
-import java.util.Map;
 
 @Configuration
 @EnableTransactionManagement
@@ -39,7 +38,6 @@ public class PostgresConfig {
                 .persistenceUnit("customer")
                 .persistenceUnit("inventory")
                 .persistenceUnit("product")
-                .properties(Map.of("hibernate.dialect", "org.hibernate.dialect.PostgreSQLDialect"))
                 .build();
     }
 

--- a/src/main/java/br/com/ecommerce/config/WebSecurityConfig.java
+++ b/src/main/java/br/com/ecommerce/config/WebSecurityConfig.java
@@ -1,0 +1,54 @@
+package br.com.ecommerce.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class WebSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .authorizeHttpRequests(requests -> requests
+                        .requestMatchers("/parameter/**").permitAll()
+                        // URLs do Swagger
+                        .requestMatchers("/swagger-ui/**").permitAll()
+                        .requestMatchers("/v3/api-docs/**").permitAll()
+                        .requestMatchers("/swagger-resources/**").permitAll()
+                        .requestMatchers("/webjars/**").permitAll()
+                        // URLs do Actuator
+                        .requestMatchers("/actuator/**").permitAll()
+                        // Outras configurações
+                        .anyRequest().authenticated())
+
+                // Abre uma popup no navegador para digitar o usuario e senha
+                .httpBasic(Customizer.withDefaults())
+                .csrf(AbstractHttpConfigurer::disable);
+
+        return http.build();
+    }
+
+    @Profile("!prod")
+    @Bean
+    public UserDetailsService userDetailsService() {
+        UserDetails user = User.withDefaultPasswordEncoder()
+                .username("usuario")
+                .password("senha")
+                .roles("PAGAMENTOS")
+                .build();
+
+        return new InMemoryUserDetailsManager(user);
+    }
+
+}

--- a/src/test/java/br/com/ecommerce/config/SecurityConfigurationTest.java
+++ b/src/test/java/br/com/ecommerce/config/SecurityConfigurationTest.java
@@ -1,0 +1,137 @@
+package br.com.ecommerce.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.not;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class SecurityConfigurationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("Deve permitir acesso público aos endpoints de parâmetros")
+    void testParameterEndpointsArePublic() throws Exception {
+        mockMvc.perform(get("/parameter/list"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/parameter/sequence"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Deve permitir acesso público aos endpoints do Swagger")
+    void testSwaggerEndpointsArePublic() throws Exception {
+        // Testa se os padrões do Swagger são públicos - retorno 404 é aceito pois significa que passou da autenticação
+        mockMvc.perform(get("/swagger-ui/test.html"))
+                .andExpect(status().isNotFound());
+
+        mockMvc.perform(get("/v3/api-docs/test"))
+                .andExpect(status().isNotFound());
+
+        mockMvc.perform(get("/swagger-resources/test"))
+                .andExpect(status().isNotFound());
+
+        mockMvc.perform(get("/webjars/test"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("Deve permitir acesso público aos endpoints do Actuator")
+    void testActuatorEndpointsArePublic() throws Exception {
+        // Testa se os padrões do Actuator são públicos - retorno 404 é aceito pois significa que passou da autenticação
+        mockMvc.perform(get("/actuator/test"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("Deve negar acesso aos endpoints protegidos sem autenticação")
+    void testProtectedEndpointsRequireAuthentication() throws Exception {
+        // Testa endpoints que devem estar protegidos
+        mockMvc.perform(get("/customer"))
+                .andExpect(status().isUnauthorized());
+
+        mockMvc.perform(post("/customer")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isUnauthorized());
+
+        mockMvc.perform(get("/product"))
+                .andExpect(status().isUnauthorized());
+
+        mockMvc.perform(get("/inventory"))
+                .andExpect(status().isUnauthorized());
+
+        mockMvc.perform(get("/payment-historic"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(username = "testuser", roles = {"PAGAMENTOS"})
+    @DisplayName("Deve permitir acesso aos endpoints protegidos com usuário autenticado")
+    void testProtectedEndpointsAccessibleWithAuthentication() throws Exception {
+        // Com usuário autenticado, não deve retornar 401 - pode retornar outros códigos como 404, 500, etc.
+        mockMvc.perform(get("/customer"))
+                .andExpect(status().is(not(401)));
+
+        mockMvc.perform(get("/product"))
+                .andExpect(status().is(not(401)));
+
+        mockMvc.perform(get("/inventory"))
+                .andExpect(status().is(not(401)));
+
+        mockMvc.perform(get("/payment-historic"))
+                .andExpect(status().is(not(401)));
+    }
+
+    @Test
+    @WithMockUser(username = "testuser")
+    @DisplayName("Deve permitir acesso aos endpoints mesmo sem roles específicas")
+    void testEndpointsAccessibleWithoutSpecificRoles() throws Exception {
+        // A configuração atual não requer roles específicas, apenas autenticação
+        mockMvc.perform(get("/customer"))
+                .andExpect(status().is(not(401)));
+    }
+
+    @Test
+    @DisplayName("Deve rejeitar credenciais inválidas")
+    void testInvalidCredentialsAreRejected() throws Exception {
+        mockMvc.perform(get("/customer")
+                        .header("Authorization", "Basic aW52YWxpZDppbnZhbGlk")) // invalid:invalid em base64
+                .andExpect(status().isUnauthorized());
+    }
+
+
+    @Test
+    @DisplayName("CSRF deve estar desabilitado")
+    void testCsrfIsDisabled() throws Exception {
+        // Se CSRF estivesse habilitado, este POST falharia
+        mockMvc.perform(post("/customer")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isUnauthorized()) // 401 por falta de auth, não 403 por CSRF
+                .andExpect(status().is(not(403)));
+    }
+
+    @Test
+    @DisplayName("HTTP Basic authentication deve estar habilitado")
+    void testHttpBasicAuthenticationEnabled() throws Exception {
+        mockMvc.perform(get("/customer"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(header().exists("WWW-Authenticate"))
+                .andExpect(header().string("WWW-Authenticate", "Basic realm=\"Realm\""));
+    }
+}

--- a/src/test/java/br/com/ecommerce/controller/CustomerControllerTest.java
+++ b/src/test/java/br/com/ecommerce/controller/CustomerControllerTest.java
@@ -1,5 +1,6 @@
 package br.com.ecommerce.controller;
 
+import br.com.ecommerce.config.WebSecurityConfig;
 import br.com.ecommerce.domain.service.CustomerService;
 import br.com.ecommerce.infra.exception.CustomerCreateException;
 import br.com.ecommerce.infra.exception.CustomerDeleteException;
@@ -12,7 +13,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.context.WebApplicationContext;
 
@@ -20,10 +23,13 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@WithMockUser(username = "usuario", password = "senha", roles = "PAGAMENTOS")
 @WebMvcTest(CustomerController.class)
+@Import(WebSecurityConfig.class)
 @AutoConfigureMockMvc
 class CustomerControllerTest {
 
@@ -128,6 +134,7 @@ class CustomerControllerTest {
                 .perform(put("/customer")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(customerRequest)))
+                .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.cpf", notNullValue()));
     }

--- a/src/test/java/br/com/ecommerce/controller/InventoryControllerTest.java
+++ b/src/test/java/br/com/ecommerce/controller/InventoryControllerTest.java
@@ -1,5 +1,6 @@
 package br.com.ecommerce.controller;
 
+import br.com.ecommerce.config.WebSecurityConfig;
 import br.com.ecommerce.domain.service.InventoryService;
 import br.com.ecommerce.infra.exception.InventoryCreateException;
 import br.com.ecommerce.infra.exception.InventoryDeleteException;
@@ -12,7 +13,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.context.WebApplicationContext;
 
@@ -23,7 +26,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@WithMockUser(username = "usuario", password = "senha", roles = "PAGAMENTOS")
 @WebMvcTest(InventoryController.class)
+@Import(WebSecurityConfig.class)
 @AutoConfigureMockMvc
 class InventoryControllerTest {
 

--- a/src/test/java/br/com/ecommerce/controller/ParameterControllerTest.java
+++ b/src/test/java/br/com/ecommerce/controller/ParameterControllerTest.java
@@ -1,5 +1,6 @@
 package br.com.ecommerce.controller;
 
+import br.com.ecommerce.config.WebSecurityConfig;
 import br.com.ecommerce.service.ParameterService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -7,6 +8,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.context.WebApplicationContext;
 
@@ -14,7 +17,9 @@ import static org.mockito.Mockito.doNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@WithMockUser(username = "usuario", password = "senha", roles = "PAGAMENTOS")
 @WebMvcTest(ParameterController.class)
+@Import(WebSecurityConfig.class)
 @AutoConfigureMockMvc
 class ParameterControllerTest {
 

--- a/src/test/java/br/com/ecommerce/controller/PaymentHistoricControllerTest.java
+++ b/src/test/java/br/com/ecommerce/controller/PaymentHistoricControllerTest.java
@@ -1,5 +1,6 @@
 package br.com.ecommerce.controller;
 
+import br.com.ecommerce.config.WebSecurityConfig;
 import br.com.ecommerce.domain.service.PaymentHistoricService;
 import br.com.ecommerce.infra.exception.PaymentHistoricCreateException;
 import br.com.ecommerce.infra.exception.PaymentHistoricDeleteException;
@@ -12,7 +13,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.context.WebApplicationContext;
 
@@ -23,7 +26,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@WithMockUser(username = "usuario", password = "senha", roles = "PAGAMENTOS")
 @WebMvcTest(PaymentHistoricController.class)
+@Import(WebSecurityConfig.class)
 @AutoConfigureMockMvc
 class PaymentHistoricControllerTest {
 

--- a/src/test/java/br/com/ecommerce/controller/ProductControllerTest.java
+++ b/src/test/java/br/com/ecommerce/controller/ProductControllerTest.java
@@ -1,5 +1,6 @@
 package br.com.ecommerce.controller;
 
+import br.com.ecommerce.config.WebSecurityConfig;
 import br.com.ecommerce.controller.impl.ProductControllerImpl;
 import br.com.ecommerce.domain.service.ProductService;
 import br.com.ecommerce.infra.exception.ProductCreateException;
@@ -13,7 +14,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.context.WebApplicationContext;
 
@@ -24,7 +27,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@WithMockUser(username = "usuario", password = "senha", roles = "PAGAMENTOS")
 @WebMvcTest(ProductControllerImpl.class)
+@Import(WebSecurityConfig.class)
 @AutoConfigureMockMvc
 class ProductControllerTest {
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -13,7 +13,7 @@ spring:
 
 postgres:
   datasource:
-    jdbc-url: jdbc:postgresql://localhost:5432/pagamentos
+    jdbc-url: jdbc:postgresql://localhost:5432/pagamentos?currentSchema=pagamentos
     username: pagamentos
     password: pagamentos
     driverClassName: org.postgresql.Driver


### PR DESCRIPTION
 - Add WebSecurityConfig with role-based access control
 - Configure public endpoints for Swagger, Actuator and parameters
 - Create default user (usuario:senha) with PAGAMENTOS role for non-prod profiles
 - Fix all controller tests to work with security (403 -> 200 OK)
 - Add security dependencies and test configurations
 - Update documentation with authentication examples