### PR TITLE
Onda -1: Spring Boot 3.3.0 -> 3.5.16 (ponte)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '3.3.0'
+    id 'org.springframework.boot' version '3.5.16'
     id 'io.spring.dependency-management' version '1.1.5'
     id 'java'
     id 'jacoco'

--- a/src/main/java/br/com/ecommerce/config/WebSecurityConfig.java
+++ b/src/main/java/br/com/ecommerce/config/WebSecurityConfig.java
@@ -10,6 +10,8 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 
@@ -22,33 +24,29 @@ public class WebSecurityConfig {
         http
                 .authorizeHttpRequests(requests -> requests
                         .requestMatchers("/parameter/**").permitAll()
-                        // URLs do Swagger
                         .requestMatchers("/swagger-ui/**").permitAll()
                         .requestMatchers("/v3/api-docs/**").permitAll()
                         .requestMatchers("/swagger-resources/**").permitAll()
                         .requestMatchers("/webjars/**").permitAll()
-                        // URLs do Actuator
                         .requestMatchers("/actuator/**").permitAll()
-                        // Outras configurações
                         .anyRequest().authenticated())
-
-                // Abre uma popup no navegador para digitar o usuario e senha
                 .httpBasic(Customizer.withDefaults())
                 .csrf(AbstractHttpConfigurer::disable);
-
         return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 
     @Profile("!prod")
     @Bean
-    public UserDetailsService userDetailsService() {
-        UserDetails user = User.withDefaultPasswordEncoder()
-                .username("usuario")
-                .password("senha")
+    public UserDetailsService userDetailsService(PasswordEncoder passwordEncoder) {
+        UserDetails user = User.withUsername("usuario")
+                .password(passwordEncoder.encode("senha"))
                 .roles("PAGAMENTOS")
                 .build();
-
         return new InMemoryUserDetailsManager(user);
     }
-
 }


### PR DESCRIPTION
Segunda onda do piloto.

Sobe ate o ultimo patch da linha 3.5, que existe para emitir warning de tudo que sera removido no Boot 4 -- ponte antes do salto maior.

Inclui:
- Bump Spring Boot 3.3.0 -> 3.5.16
- Achado pre-existente corrigido: User.withDefaultPasswordEncoder() -> BCryptPasswordEncoder (revelado por warning de depreciacao do 3.5.16, nao causado por ele -- contrato preservado)