### PR TITLE
Onda -1b: MockBean -> MockitoBean via OpenRewrite

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.5'
     id 'java'
     id 'jacoco'
+    id 'org.openrewrite.rewrite' version '6.16.3'
 }
 
 group = 'br.com'
@@ -13,6 +14,10 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+}
+
+rewrite {
+    activeRecipe("br.com.sicredi.rewrite.MigrateMockBeanToMockitoBean")
 }
 
 repositories {

--- a/rewrite.yml
+++ b/rewrite.yml
@@ -1,0 +1,32 @@
+# rewrite.yml — br.com.sicredi.rewrite.MigrateMockBeanToMockitoBean
+#
+# Substitui @MockBean/@SpyBean (deprecados desde Boot 3.4.0, marcados para
+# remocao na 4.0.0 -- ver context/breaking-changes/mockbean-mockitobean.md)
+# por @MockitoBean/@MockitoSpyBean.
+#
+# Usa apenas org.openrewrite.java.ChangeType, recipe-nucleo sob Apache
+# License 2.0 -- nao depende do modulo rewrite-spring (Moderne Source
+# Available License), entao nao entra na pendencia de confirmacao juridica
+# registrada para UpgradeSpringBoot_4_0.
+#
+# NAO cobre @MockBeans (container a nivel de classe) -- se o servico usar
+# esse padrao, precisa de refatoracao manual separada (ver nota no arquivo
+# de breaking changes).
+#
+# Coloque este arquivo na raiz do projeto (mesmo diretorio do build.gradle).
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: br.com.sicredi.rewrite.MigrateMockBeanToMockitoBean
+displayName: Migrar MockBean/SpyBean para MockitoBean/MockitoSpyBean
+description: >
+  Boot 3.4+ depreciou @MockBean e @SpyBean (org.springframework.boot.test.mock.mockito)
+  em favor de @MockitoBean e @MockitoSpyBean (org.springframework.test.context.bean.override.mockito).
+  Remocao prevista para Boot 4.0.0.
+recipeList:
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.boot.test.mock.mockito.MockBean
+      newFullyQualifiedTypeName: org.springframework.test.context.bean.override.mockito.MockitoBean
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.boot.test.mock.mockito.SpyBean
+      newFullyQualifiedTypeName: org.springframework.test.context.bean.override.mockito.MockitoSpyBean

--- a/src/test/java/br/com/ecommerce/controller/CustomerControllerTest.java
+++ b/src/test/java/br/com/ecommerce/controller/CustomerControllerTest.java
@@ -12,10 +12,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.context.WebApplicationContext;
 
@@ -33,7 +33,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 class CustomerControllerTest {
 
-    @MockBean
+    @MockitoBean
     private CustomerService customerService;
 
     @Autowired

--- a/src/test/java/br/com/ecommerce/controller/InventoryControllerTest.java
+++ b/src/test/java/br/com/ecommerce/controller/InventoryControllerTest.java
@@ -12,10 +12,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.context.WebApplicationContext;
 
@@ -32,7 +32,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 class InventoryControllerTest {
 
-    @MockBean
+    @MockitoBean
     private InventoryService inventoryService;
 
     @Autowired

--- a/src/test/java/br/com/ecommerce/controller/ParameterControllerTest.java
+++ b/src/test/java/br/com/ecommerce/controller/ParameterControllerTest.java
@@ -7,9 +7,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.context.WebApplicationContext;
 
@@ -23,7 +23,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 class ParameterControllerTest {
 
-    @MockBean
+    @MockitoBean
     private ParameterService parameterService;
 
     @Autowired

--- a/src/test/java/br/com/ecommerce/controller/PaymentHistoricControllerTest.java
+++ b/src/test/java/br/com/ecommerce/controller/PaymentHistoricControllerTest.java
@@ -12,10 +12,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.context.WebApplicationContext;
 
@@ -32,7 +32,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 class PaymentHistoricControllerTest {
 
-    @MockBean
+    @MockitoBean
     private PaymentHistoricService paymentHistoricService;
 
     @Autowired

--- a/src/test/java/br/com/ecommerce/controller/ProductControllerTest.java
+++ b/src/test/java/br/com/ecommerce/controller/ProductControllerTest.java
@@ -13,10 +13,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.context.WebApplicationContext;
 
@@ -33,7 +33,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 class ProductControllerTest {
 
-    @MockBean
+    @MockitoBean
     private ProductService productService;
 
     @Autowired


### PR DESCRIPTION
Terceira onda do piloto.

@MockBean/@SpyBean deprecados desde Boot 3.4.0, remocao prevista para 4.0.0.

Inclui:
- Plugin org.openrewrite.rewrite + recipe propria (recipes/rewrite.yml, br.com.sicredi.rewrite.MigrateMockBeanToMockitoBean)
- Recipe usa apenas ChangeType (core OpenRewrite, Apache 2.0) -- nao depende do modulo rewrite-spring (Moderne Source Available License), evitando pendencia juridica para esta troca especifica
- 6 arquivos afetados: SecurityConfigurationTest (ja migrado na Onda 0) + 5 controllers restantes, migrados via rewriteRun nesta onda
- Suite completa validada verde -- diferenca comportamental documentada pelo Spring entre as anotacoes nao se manifestou neste servico