### PR TITLE
Onda 1: Java 19 -> 21 via Gradle toolchain

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,12 @@ plugins {
 
 group = 'br.com'
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '19'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
 
 configurations {
     compileOnly {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,5 @@
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
+}
+
 rootProject.name = 'ecommerce'


### PR DESCRIPTION
Quarta e ultima onda desta fase do piloto.

Substitui sourceCompatibility='19' por java.toolchain.languageVersion(21),
usando org.gradle.toolchains.foojay-resolver-convention.

Motivacao: Boot 4.0.x exige Java 21 no minimo para compilar -- este e um
pre-requisito, nao o destino final (Java 25 LTS ainda pendente, onda
separada).

Build hermetica: o Gradle resolve o JDK sozinho, independente de PATH,
JAVA_HOME ou qual JDK esta ativo na IDE de cada maquina. Neste ambiente,
auto-detectou um Corretto 21.0.8 ja instalado pelo IntelliJ -- zero
download de rede necessario. Relevante para os proximos 349 servicos:
elimina a divergencia de ambiente entre desenvolvedores como causa de
build quebrado.

Achado registrado para observacao (nao bloqueante): jacocoTestReport
roda in-process no JVM host do daemon Gradle, nao no toolchain declarado
-- pode nao acompanhar o toolchain em saltos futuros maiores.