### PR TITLE
Onda 1b: Java 21 -> 25 LTS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 
@@ -46,8 +46,8 @@ dependencies {
 
     testImplementation "org.springframework.boot:spring-boot-starter-test"
 
-    compileOnly 'org.projectlombok:lombok:1.18.32'
-    annotationProcessor 'org.projectlombok:lombok:1.18.32'
+    compileOnly 'org.projectlombok:lombok:1.18.42'
+    annotationProcessor 'org.projectlombok:lombok:1.18.42'
 }
 
 tasks.named('test') {


### PR DESCRIPTION
Quinta onda tecnica do piloto -- alvo final de Java atingido.

foojay-resolver baixou o JDK automaticamente pela primeira vez neste piloto
(as ondas anteriores encontraram JDK ja instalado pelo IntelliJ). Confirma
que a rede desta maquina permite acesso a api.foojay.io -- ainda pendente
confirmar se a rede corporativa do Sicredi permite o mesmo, tanto em
maquinas de dev quanto em runners de GitLab CI.

Bloqueador real encontrado e corrigido: Lombok 1.18.32 nao compila sob
JDK 25 (ExceptionInInitializerError). Bump para 1.18.42 resolveu -- mesma
correcao usada por outro time com o mesmo erro. Achado documentado em
context/breaking-changes/lombok-java25.md no kit -- praticamente certo de
se repetir em outros servicos do Sicredi que usem Lombok (maioria).

Com esta onda, o Java do piloto chega ao destino final (25 LTS). Falta
apenas Boot 4.1 para o programa deste servico estar completo.