### PR TITLE
test: golden files de contrato JSON (Customer, Product, Inventory, PaymentHistoric)

### DIFF
--- a/src/test/java/br/com/ecommerce/golden/CustomerGoldenTest.java
+++ b/src/test/java/br/com/ecommerce/golden/CustomerGoldenTest.java
@@ -1,0 +1,64 @@
+package br.com.ecommerce.golden;
+
+import br.com.ecommerce.controller.request.CustomerRequest;
+import br.com.ecommerce.controller.response.CustomerResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.json.JsonTest;
+import org.springframework.boot.test.json.JacksonTester;
+import org.springframework.core.io.ClassPathResource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@JsonTest
+class CustomerGoldenTest {
+
+    @Autowired
+    private JacksonTester<CustomerRequest> requestJson;
+
+    @Autowired
+    private JacksonTester<CustomerResponse> responseJson;
+
+    @Test
+    void serializacaoDeCustomerRequest_naoMudou() throws Exception {
+        CustomerRequest fixture = CustomerRequest.builder()
+                .cpf("12345678910")
+                .name("Bruno")
+                .birthDate("15111989")
+                .gender("M")
+                .build();
+
+        assertThat(requestJson.write(fixture))
+                .isEqualToJson(new ClassPathResource("golden/customer-request.json"));
+    }
+
+    @Test
+    void serializacaoDeCustomerResponse_naoMudou() throws Exception {
+        CustomerResponse fixture = CustomerResponse.builder()
+                .cpf("12345678910")
+                .name("Bruno")
+                .birthDate("15111989")
+                .gender("M")
+                .build();
+
+        assertThat(responseJson.write(fixture))
+                .isEqualToJson(new ClassPathResource("golden/customer-response.json"));
+    }
+
+    @Test
+    void roundTripDeCustomerRequest_preservaOsDados() throws Exception {
+        String jsonContent = requestJson.write(CustomerRequest.builder()
+                .cpf("12345678910")
+                .name("Bruno")
+                .birthDate("15111989")
+                .gender("M")
+                .build()).getJson();
+
+        CustomerRequest desserializado = requestJson.parseObject(jsonContent);
+
+        assertThat(desserializado.getCpf()).isEqualTo("12345678910");
+        assertThat(desserializado.getName()).isEqualTo("Bruno");
+        assertThat(desserializado.getBirthDate()).isEqualTo("15111989");
+        assertThat(desserializado.getGender()).isEqualTo("M");
+    }
+}

--- a/src/test/java/br/com/ecommerce/golden/InventoryGoldenTest.java
+++ b/src/test/java/br/com/ecommerce/golden/InventoryGoldenTest.java
@@ -1,0 +1,63 @@
+package br.com.ecommerce.golden;
+
+import br.com.ecommerce.controller.request.InventoryRequest;
+import br.com.ecommerce.controller.response.InventoryResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.json.JsonTest;
+import org.springframework.boot.test.json.JacksonTester;
+import org.springframework.core.io.ClassPathResource;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@JsonTest
+class InventoryGoldenTest {
+
+    @Autowired
+    private JacksonTester<InventoryRequest> requestJson;
+
+    @Autowired
+    private JacksonTester<InventoryResponse> responseJson;
+
+    private InventoryRequest fixtureRequest() {
+        return InventoryRequest.builder()
+                .id(1)
+                .availableQuantity(new BigDecimal("100"))
+                .reservedQuantity(new BigDecimal("10"))
+                .productCode("AB1234")
+                .build();
+    }
+
+    private InventoryResponse fixtureResponse() {
+        return InventoryResponse.builder()
+                .id(1)
+                .availableQuantity(new BigDecimal("100"))
+                .reservedQuantity(new BigDecimal("10"))
+                .productCode("AB1234")
+                .build();
+    }
+
+    @Test
+    void serializacaoDeInventoryRequest_naoMudou() throws Exception {
+        assertThat(requestJson.write(fixtureRequest()))
+                .isEqualToJson(new ClassPathResource("golden/inventory-request.json"));
+    }
+
+    @Test
+    void serializacaoDeInventoryResponse_naoMudou() throws Exception {
+        assertThat(responseJson.write(fixtureResponse()))
+                .isEqualToJson(new ClassPathResource("golden/inventory-response.json"));
+    }
+
+    @Test
+    void roundTripDeInventoryRequest_preservaTiposEValores() throws Exception {
+        String jsonContent = requestJson.write(fixtureRequest()).getJson();
+        InventoryRequest desserializado = requestJson.parseObject(jsonContent);
+
+        assertThat(desserializado.getAvailableQuantity()).isEqualByComparingTo(new BigDecimal("100"));
+        assertThat(desserializado.getReservedQuantity()).isEqualByComparingTo(new BigDecimal("10"));
+        assertThat(desserializado.getProductCode()).isEqualTo("AB1234");
+    }
+}

--- a/src/test/java/br/com/ecommerce/golden/PaymentHistoricGoldenTest.java
+++ b/src/test/java/br/com/ecommerce/golden/PaymentHistoricGoldenTest.java
@@ -1,0 +1,63 @@
+package br.com.ecommerce.golden;
+
+import br.com.ecommerce.controller.request.PaymentHistoricRequest;
+import br.com.ecommerce.controller.response.PaymentHistoricResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.json.JsonTest;
+import org.springframework.boot.test.json.JacksonTester;
+import org.springframework.core.io.ClassPathResource;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@JsonTest
+class PaymentHistoricGoldenTest {
+
+    @Autowired
+    private JacksonTester<PaymentHistoricRequest> requestJson;
+
+    @Autowired
+    private JacksonTester<PaymentHistoricResponse> responseJson;
+
+    private PaymentHistoricRequest fixtureRequest() {
+        return PaymentHistoricRequest.builder()
+                .id(1)
+                .description("Test Payment")
+                .type("CREDIT_CARD")
+                .date(LocalDate.of(2026, 7, 19))
+                .build();
+    }
+
+    private PaymentHistoricResponse fixtureResponse() {
+        return PaymentHistoricResponse.builder()
+                .id(1)
+                .description("Test Payment")
+                .type("CREDIT_CARD")
+                .date(LocalDate.of(2026, 7, 19))
+                .build();
+    }
+
+    @Test
+    void serializacaoDePaymentHistoricRequest_naoMudou() throws Exception {
+        assertThat(requestJson.write(fixtureRequest()))
+                .isEqualToJson(new ClassPathResource("golden/payment-historic-request.json"));
+    }
+
+    @Test
+    void serializacaoDePaymentHistoricResponse_naoMudou() throws Exception {
+        assertThat(responseJson.write(fixtureResponse()))
+                .isEqualToJson(new ClassPathResource("golden/payment-historic-response.json"));
+    }
+
+    @Test
+    void roundTripDePaymentHistoricRequest_preservaTiposEValores() throws Exception {
+        String jsonContent = requestJson.write(fixtureRequest()).getJson();
+        PaymentHistoricRequest desserializado = requestJson.parseObject(jsonContent);
+
+        assertThat(desserializado.getDate()).isEqualTo(LocalDate.of(2026, 7, 19));
+        assertThat(desserializado.getDescription()).isEqualTo("Test Payment");
+        assertThat(desserializado.getType()).isEqualTo("CREDIT_CARD");
+    }
+}

--- a/src/test/java/br/com/ecommerce/golden/ProductGoldenTest.java
+++ b/src/test/java/br/com/ecommerce/golden/ProductGoldenTest.java
@@ -1,0 +1,68 @@
+package br.com.ecommerce.golden;
+
+import br.com.ecommerce.controller.request.ProductRequest;
+import br.com.ecommerce.controller.response.ProductResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.json.JsonTest;
+import org.springframework.boot.test.json.JacksonTester;
+import org.springframework.core.io.ClassPathResource;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@JsonTest
+class ProductGoldenTest {
+
+    @Autowired
+    private JacksonTester<ProductRequest> requestJson;
+
+    @Autowired
+    private JacksonTester<ProductResponse> responseJson;
+
+    private ProductRequest fixtureRequest() {
+        return ProductRequest.builder()
+                .code("AB1234")
+                .category("Electronics")
+                .title("Test Product")
+                .description("Test Product Description")
+                .weight(new BigDecimal("1.50"))
+                .dateRegister(LocalDate.of(2026, 7, 19))
+                .build();
+    }
+
+    private ProductResponse fixtureResponse() {
+        return ProductResponse.builder()
+                .code("AB1234")
+                .category("Electronics")
+                .title("Test Product")
+                .description("Test Product Description")
+                .weight(new BigDecimal("1.50"))
+                .dateRegister(LocalDate.of(2026, 7, 19))
+                .build();
+    }
+
+    @Test
+    void serializacaoDeProductRequest_naoMudou() throws Exception {
+        assertThat(requestJson.write(fixtureRequest()))
+                .isEqualToJson(new ClassPathResource("golden/product-request.json"));
+    }
+
+    @Test
+    void serializacaoDeProductResponse_naoMudou() throws Exception {
+        assertThat(responseJson.write(fixtureResponse()))
+                .isEqualToJson(new ClassPathResource("golden/product-response.json"));
+    }
+
+    @Test
+    void roundTripDeProductRequest_preservaTiposEValores() throws Exception {
+        String jsonContent = requestJson.write(fixtureRequest()).getJson();
+        ProductRequest desserializado = requestJson.parseObject(jsonContent);
+
+        assertThat(desserializado.getWeight()).isEqualByComparingTo(new BigDecimal("1.50"));
+        assertThat(desserializado.getDateRegister()).isEqualTo(LocalDate.of(2026, 7, 19));
+        assertThat(desserializado.getCode()).isEqualTo("AB1234");
+    }
+}

--- a/src/test/resources/golden/customer-request.json
+++ b/src/test/resources/golden/customer-request.json
@@ -1,0 +1,6 @@
+{
+  "cpf" : "12345678910",
+  "name" : "Bruno",
+  "birthDate" : "15111989",
+  "gender" : "M"
+}

--- a/src/test/resources/golden/customer-response.json
+++ b/src/test/resources/golden/customer-response.json
@@ -1,0 +1,6 @@
+{
+  "cpf" : "12345678910",
+  "name" : "Bruno",
+  "birthDate" : "15111989",
+  "gender" : "M"
+}

--- a/src/test/resources/golden/inventory-request.json
+++ b/src/test/resources/golden/inventory-request.json
@@ -1,0 +1,6 @@
+{
+  "id" : 1,
+  "availableQuantity" : 100,
+  "reservedQuantity" : 10,
+  "productCode" : "AB1234"
+}

--- a/src/test/resources/golden/inventory-response.json
+++ b/src/test/resources/golden/inventory-response.json
@@ -1,0 +1,6 @@
+{
+  "id" : 1,
+  "availableQuantity" : 100,
+  "reservedQuantity" : 10,
+  "productCode" : "AB1234"
+}

--- a/src/test/resources/golden/payment-historic-request.json
+++ b/src/test/resources/golden/payment-historic-request.json
@@ -1,0 +1,6 @@
+{
+  "id" : 1,
+  "description" : "Test Payment",
+  "type" : "CREDIT_CARD",
+  "date" : "2026-07-19"
+}

--- a/src/test/resources/golden/payment-historic-response.json
+++ b/src/test/resources/golden/payment-historic-response.json
@@ -1,0 +1,6 @@
+{
+  "id" : 1,
+  "description" : "Test Payment",
+  "type" : "CREDIT_CARD",
+  "date" : "2026-07-19"
+}

--- a/src/test/resources/golden/product-request.json
+++ b/src/test/resources/golden/product-request.json
@@ -1,0 +1,8 @@
+{
+  "code" : "AB1234",
+  "category" : "Electronics",
+  "title" : "Test Product",
+  "description" : "Test Product Description",
+  "weight" : 1.50,
+  "dateRegister" : "2026-07-19"
+}

--- a/src/test/resources/golden/product-response.json
+++ b/src/test/resources/golden/product-response.json
@@ -1,0 +1,8 @@
+{
+  "code" : "AB1234",
+  "category" : "Electronics",
+  "title" : "Test Product",
+  "description" : "Test Product Description",
+  "weight" : 1.50,
+  "dateRegister" : "2026-07-19"
+}


### PR DESCRIPTION
## Summary

Rede de segurança (onda-2) preparando o terreno para o upgrade Spring Boot 4 / Jackson 3: testes de golden file que travam o formato exato de serialização/deserialização JSON dos 4 controllers apontados pelo `rewriteDryRun` anterior como afetados pela migração Jackson 2 -> 3 (ver `context/breaking-changes/dryrun-boot4-achados.md` no upgrade-kit).

- `CustomerGoldenTest` — request/response (já existente nesta sessão)
- `ProductGoldenTest` — request/response, cobre `BigDecimal`/`LocalDate` (já existente)
- `InventoryGoldenTest` — request/response, novo. Cobre `BigDecimal` de escala 0 (`availableQuantity`, `reservedQuantity`)
- `PaymentHistoricGoldenTest` — request/response, novo. Cobre `LocalDate`

Cada par de testes verifica: (1) a serialização não mudou, comparando contra fixture JSON em `src/test/resources/golden/`; (2) round-trip preserva tipos e valores após parse.

Os fixtures de `Inventory`/`PaymentHistoric` foram derivados de um teste de descoberta rodado contra o `ObjectMapper` real do contexto Spring (não adivinhados) — confirmou que `BigDecimal` de escala 0 serializa como número puro (`100`, não `100.00`) e `LocalDate` serializa em ISO (`"2026-07-19"`), consistente com o padrão já visto em `ProductGoldenTest`.

## Test plan

- [x] `./gradlew test --tests "br.com.ecommerce.golden.*"` — 4 classes, todos verdes
- [x] `./gradlew build` completo — verde, sem regressão

🤖 Generated with [Claude Code](https://claude.com/claude-code)