### PR TITLE
fix: fecha pendencias do Testcontainers duplo (ddl-auto, SQL baseline, N+1)

### DIFF
--- a/src/test/java/br/com/ecommerce/golden/DualDatabasePersistenceGoldenTest.java
+++ b/src/test/java/br/com/ecommerce/golden/DualDatabasePersistenceGoldenTest.java
@@ -10,11 +10,13 @@ import br.com.ecommerce.domain.repository.mysql.PaymentHistoricRepository;
 import br.com.ecommerce.domain.repository.postgres.CustomerRepository;
 import br.com.ecommerce.domain.repository.postgres.InventoryRepository;
 import br.com.ecommerce.domain.repository.postgres.ProductRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.MySQLContainer;
@@ -22,7 +24,9 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import java.io.IOException;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.util.Optional;
 
@@ -34,17 +38,30 @@ import static org.assertj.core.api.Assertions.assertThat;
  * classes de configuracao usadas pela aplicacao, cada uma com seu
  * EntityManagerFactory/TransactionManager independente.
  *
- * ddl-auto=create-drop e usado apenas neste contexto de teste (via
- * @DynamicPropertySource) porque nao ha nenhum script CREATE TABLE no
- * repositorio -- os arquivos Flyway existentes contem so INSERT e
- * pressupoem schema pre-existente. As tabelas aqui sao geradas pelo
- * proprio Hibernate a partir das @Entity reais, nao inventadas.
+ * ddl-auto=create (nao create-drop) e usado apenas neste contexto de
+ * teste (via @DynamicPropertySource) porque nao ha nenhum script CREATE
+ * TABLE no repositorio -- os arquivos Flyway existentes contem so
+ * INSERT e pressupoem schema pre-existente. As tabelas aqui sao geradas
+ * pelo proprio Hibernate a partir das @Entity reais, nao inventadas.
+ * "create" (sem drop) evita que o Hibernate tente DROP TABLE no
+ * shutdown do contexto Spring, momento em que os containers
+ * Testcontainers ja foram derrubados -- com create-drop isso gerava
+ * dois timeouts de 30s (HikariPool "Connection is not available") no
+ * final da execucao, mesmo com o teste passando.
  *
  * FlywayAutoConfiguration e excluido de proposito: o Flyway real da
  * aplicacao roda via FlywayConfig (@PostConstruct manual, fora do
  * mecanismo automatico do Boot), que nao esta no escopo deste teste;
  * sem a exclusao, o auto-config do Boot tentaria migrar a partir do
  * local padrao classpath:db/migration, que nao existe neste projeto.
+ *
+ * SqlCapturingStatementInspector captura, via
+ * hibernate.session_factory.statement_inspector, cada SQL que o
+ * Hibernate executa. Cada teste compara o SQL capturado contra um
+ * arquivo de referencia versionado em src/test/resources/sql-baseline/
+ * (mesmo principio dos golden files de JSON, mas para SQL -- serve de
+ * baseline pre-Hibernate-7) e verifica a contagem de SELECT/INSERT por
+ * operacao como guarda contra N+1 futuro.
  */
 @Testcontainers
 @EnableAutoConfiguration(exclude = FlywayAutoConfiguration.class)
@@ -77,7 +94,23 @@ class DualDatabasePersistenceGoldenTest {
         registry.add("mysql.datasource.password", mysql::getPassword);
         registry.add("mysql.datasource.driverClassName", mysql::getDriverClassName);
 
-        registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "create");
+        registry.add("spring.jpa.properties.hibernate.session_factory.statement_inspector",
+                SqlCapturingStatementInspector.class::getName);
+    }
+
+    @BeforeEach
+    void limpaSqlCapturado() {
+        SqlCapturingStatementInspector.clear();
+    }
+
+    private void assertSqlBaseline(String resourceName) throws IOException {
+        String sqlCapturado = String.join("\n", SqlCapturingStatementInspector.captured());
+        String sqlEsperado = new ClassPathResource("sql-baseline/" + resourceName)
+                .getContentAsString(StandardCharsets.UTF_8)
+                .replace("\r\n", "\n");
+
+        assertThat(sqlCapturado.strip()).isEqualTo(sqlEsperado.strip());
     }
 
     @Autowired
@@ -93,7 +126,7 @@ class DualDatabasePersistenceGoldenTest {
     private PaymentHistoricRepository paymentHistoricRepository;
 
     @Test
-    void gravaELeCustomer_noPostgres() {
+    void gravaELeCustomer_noPostgres() throws IOException {
         CustomerEntity fixture = new CustomerEntity();
         fixture.setCpf("12345678910");
         fixture.setName("Bruno");
@@ -108,10 +141,14 @@ class DualDatabasePersistenceGoldenTest {
         assertThat(encontrado.get().getName()).isEqualTo("Bruno");
         assertThat(encontrado.get().getBirthDate()).isEqualTo("15111989");
         assertThat(encontrado.get().getGender()).isEqualTo("M");
+
+        assertThat(SqlCapturingStatementInspector.countStatementsStartingWith("select")).isEqualTo(2);
+        assertThat(SqlCapturingStatementInspector.countStatementsStartingWith("insert")).isEqualTo(1);
+        assertSqlBaseline("customer-insert.sql");
     }
 
     @Test
-    void gravaELeInventory_noPostgres() {
+    void gravaELeInventory_noPostgres() throws IOException {
         InventoryEntity fixture = new InventoryEntity();
         fixture.setId(1);
         fixture.setAvailableQuantity(new BigDecimal("100"));
@@ -126,10 +163,14 @@ class DualDatabasePersistenceGoldenTest {
         assertThat(encontrado.get().getAvailableQuantity()).isEqualByComparingTo(new BigDecimal("100"));
         assertThat(encontrado.get().getReservedQuantity()).isEqualByComparingTo(new BigDecimal("10"));
         assertThat(encontrado.get().getProductCode()).isEqualTo("AB1234");
+
+        assertThat(SqlCapturingStatementInspector.countStatementsStartingWith("select")).isEqualTo(2);
+        assertThat(SqlCapturingStatementInspector.countStatementsStartingWith("insert")).isEqualTo(1);
+        assertSqlBaseline("inventory-insert.sql");
     }
 
     @Test
-    void gravaELeProduct_noPostgres() {
+    void gravaELeProduct_noPostgres() throws IOException {
         ProductEntity fixture = new ProductEntity();
         fixture.setCode("AB1234");
         fixture.setCategory("Electronics");
@@ -145,10 +186,14 @@ class DualDatabasePersistenceGoldenTest {
         assertThat(encontrado).isPresent();
         assertThat(encontrado.get().getWeight()).isEqualByComparingTo(new BigDecimal("1.50"));
         assertThat(encontrado.get().getDateRegister()).isEqualTo(LocalDate.of(2026, 7, 19));
+
+        assertThat(SqlCapturingStatementInspector.countStatementsStartingWith("select")).isEqualTo(2);
+        assertThat(SqlCapturingStatementInspector.countStatementsStartingWith("insert")).isEqualTo(1);
+        assertSqlBaseline("product-insert.sql");
     }
 
     @Test
-    void gravaELePaymentHistoric_noMysql() {
+    void gravaELePaymentHistoric_noMysql() throws IOException {
         PaymentHistoricEntity fixture = new PaymentHistoricEntity();
         fixture.setId(1);
         fixture.setDescription("Test Payment");
@@ -163,5 +208,9 @@ class DualDatabasePersistenceGoldenTest {
         assertThat(encontrado.get().getDescription()).isEqualTo("Test Payment");
         assertThat(encontrado.get().getType()).isEqualTo("CREDIT_CARD");
         assertThat(encontrado.get().getDate()).isEqualTo(LocalDate.of(2026, 7, 19));
+
+        assertThat(SqlCapturingStatementInspector.countStatementsStartingWith("select")).isEqualTo(2);
+        assertThat(SqlCapturingStatementInspector.countStatementsStartingWith("insert")).isEqualTo(1);
+        assertSqlBaseline("payment-historic-insert.sql");
     }
 }

--- a/src/test/java/br/com/ecommerce/golden/SqlCapturingStatementInspector.java
+++ b/src/test/java/br/com/ecommerce/golden/SqlCapturingStatementInspector.java
@@ -1,0 +1,46 @@
+package br.com.ecommerce.golden;
+
+import org.hibernate.resource.jdbc.spi.StatementInspector;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Registrado via propriedade Hibernate (hibernate.session_factory.statement_inspector),
+ * que instancia esta classe por reflexao -- por isso o estado precisa ser
+ * estatico: nao ha como o teste segurar a instancia que o Hibernate cria.
+ * As duas SessionFactory (Postgres e MySQL) compartilham a mesma lista
+ * estatica, o que e aceitavel porque cada teste limpa a lista antes de
+ * rodar e le logo em seguida, sem concorrencia entre metodos de teste.
+ */
+public class SqlCapturingStatementInspector implements StatementInspector {
+
+    private static final List<String> CAPTURED = Collections.synchronizedList(new ArrayList<>());
+
+    @Override
+    public String inspect(String sql) {
+        CAPTURED.add(sql);
+        return sql;
+    }
+
+    static List<String> captured() {
+        synchronized (CAPTURED) {
+            return new ArrayList<>(CAPTURED);
+        }
+    }
+
+    static void clear() {
+        CAPTURED.clear();
+    }
+
+    static long countStatementsStartingWith(String keyword) {
+        String upperKeyword = keyword.toUpperCase(Locale.ROOT);
+        synchronized (CAPTURED) {
+            return CAPTURED.stream()
+                    .filter(sql -> sql.trim().toUpperCase(Locale.ROOT).startsWith(upperKeyword))
+                    .count();
+        }
+    }
+}

--- a/src/test/resources/sql-baseline/customer-insert.sql
+++ b/src/test/resources/sql-baseline/customer-insert.sql
@@ -1,0 +1,3 @@
+select ce1_0.cpf,ce1_0.birth_date,ce1_0.gender,ce1_0.name from customer ce1_0 where ce1_0.cpf=?
+insert into customer (birth_date,gender,name,cpf) values (?,?,?,?)
+select ce1_0.cpf,ce1_0.birth_date,ce1_0.gender,ce1_0.name from customer ce1_0 where ce1_0.cpf=?

--- a/src/test/resources/sql-baseline/inventory-insert.sql
+++ b/src/test/resources/sql-baseline/inventory-insert.sql
@@ -1,0 +1,3 @@
+select ie1_0.id,ie1_0.available_quantity,ie1_0.product_code,ie1_0.reserved_quantity from inventory ie1_0 where ie1_0.id=?
+insert into inventory (available_quantity,product_code,reserved_quantity,id) values (?,?,?,?)
+select ie1_0.id,ie1_0.available_quantity,ie1_0.product_code,ie1_0.reserved_quantity from inventory ie1_0 where ie1_0.id=?

--- a/src/test/resources/sql-baseline/payment-historic-insert.sql
+++ b/src/test/resources/sql-baseline/payment-historic-insert.sql
@@ -1,0 +1,3 @@
+select phe1_0.id,phe1_0.date,phe1_0.description,phe1_0.type from payment_historic phe1_0 where phe1_0.id=?
+insert into payment_historic (date,description,type,id) values (?,?,?,?)
+select phe1_0.id,phe1_0.date,phe1_0.description,phe1_0.type from payment_historic phe1_0 where phe1_0.id=?

--- a/src/test/resources/sql-baseline/product-insert.sql
+++ b/src/test/resources/sql-baseline/product-insert.sql
@@ -1,0 +1,3 @@
+select pe1_0.code,pe1_0.category,pe1_0.date_register,pe1_0.description,pe1_0.title,pe1_0.weight from product pe1_0 where pe1_0.code=?
+insert into product (category,date_register,description,title,weight,code) values (?,?,?,?,?,?)
+select pe1_0.code,pe1_0.category,pe1_0.date_register,pe1_0.description,pe1_0.title,pe1_0.weight from product pe1_0 where pe1_0.code=?


### PR DESCRIPTION
Fecha as 3 pendencias identificadas na revisao da onda anterior (PR #27).

Antes: build com 2 timeouts de 30s no shutdown (race entre Testcontainers e Hibernate ddl-auto=create-drop). Depois: 53s, zero timeouts.

Golden files de SQL agora existem como baseline real pre-Hibernate-7, com guarda de contagem exata de query para detectar N+1 futuro.

Revisado linha por linha antes da aprovacao -- incluindo verificacao cruzada dos Config.java para confirmar que o statement_inspector se propaga corretamente para os dois EntityManagerFactory (Postgres e MySQL).