### PR TITLE
docs: sincroniza README com o estado real do serviço pós-onda-4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,41 @@
 # 🛒 E-commerce REST API
 
-[![Java](https://img.shields.io/badge/Java-19-orange.svg)](https://openjdk.java.net/)
-[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-3.0.2-brightgreen.svg)](https://spring.io/projects/spring-boot)
-[![Gradle](https://img.shields.io/badge/Gradle-7.6-blue.svg)](https://gradle.org/)
+[![Java](https://img.shields.io/badge/Java-25%20LTS-orange.svg)](https://openjdk.java.net/)
+[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.1.0-brightgreen.svg)](https://spring.io/projects/spring-boot)
+[![Hibernate](https://img.shields.io/badge/Hibernate-7.4.1-59666C.svg)](https://hibernate.org/)
+[![Gradle](https://img.shields.io/badge/Gradle-8.14.5-blue.svg)](https://gradle.org/)
 
-> A comprehensive REST API e-commerce platform built for learning and demonstration purposes, featuring modern Spring Boot architecture with multiple database integrations and security.
+> A comprehensive REST API e-commerce platform built for learning and demonstration purposes, featuring modern Spring Boot architecture with multiple database integrations and security. Also used as the pilot service for a Java 25 / Spring Boot 4 upgrade program.
 
 ## ✨ Features
 
-- 🔒 **Spring Security** with HTTP Basic authentication
-- 🗃️ **Multi-database support** (PostgreSQL + MySQL)
-- 📚 **OpenAPI 3.0** documentation with Swagger UI
+- 🔒 **Spring Security 7** with HTTP Basic authentication
+- 🗃️ **Multi-database support** (PostgreSQL + MySQL), each with its own `EntityManagerFactory`/`TransactionManager`
+- 📚 **OpenAPI 3** documentation with Swagger UI (springdoc-openapi 3.0.3)
 - 🔄 **Database migrations** with Flyway
 - ✅ **Comprehensive validation** with Bean Validation
 - 🐳 **Docker support** for local development
-- 🧪 **Unit & Integration tests** with high coverage
+- 🧪 **Golden-file regression tests**: JSON serialization contracts + a SQL baseline captured via Testcontainers (MySQL + PostgreSQL running simultaneously)
 - 📈 **Exception handling** with global error responses
 
 ## 🚀 Quick Start
 
 ### Prerequisites
 
-- ☕ Java 19+
-- 🐳 Docker & Docker Compose
+- ☕ Java 25 (the Gradle toolchain auto-provisions the JDK — a local install isn't strictly required)
+- 🐳 Docker or Docker-compatible runtime (Podman works too, via `DOCKER_HOST`)
 - 🔧 IDE with Gradle support
 
 ### 🏃‍♂️ Running Locally
 
 1. **Start the databases**
    ```bash
-   docker compose up
+   docker compose -f src/main/resources/docker-compose.yml up
    ```
 
 2. **Run the application**
    ```bash
-   ./gradlew bootRun -Dspring.profiles.active=local
+   ./gradlew bootRun
    ```
 
 3. **Access the API**
@@ -62,10 +63,12 @@ curl -X GET "http://localhost:8080/ecommerce/customer" \
 src/
 ├── main/java/br/com/ecommerce/
 │   ├── controller/          # REST Controllers
-│   ├── domain/             # Domain Services & Models
-│   ├── infra/              # Infrastructure (DB, Config)
-│   └── config/             # Configuration Classes
-└── test/                   # Unit & Integration Tests
+│   ├── domain/              # Domain Services, Entities & Repositories
+│   ├── infra/                # Infrastructure (exception handling, etc.)
+│   └── config/               # Configuration Classes (datasources, security, flyway)
+└── test/
+    ├── java/br/com/ecommerce/golden/   # JSON + SQL golden-file regression tests
+    └── java/br/com/ecommerce/...       # Unit & slice tests
 ```
 
 ### 🗄️ Database Schema
@@ -76,63 +79,88 @@ src/
 
 | Category | Technology |
 |----------|------------|
-| **Language** | Java 19 |
-| **Framework** | Spring Boot 3.0.2 |
-| **Security** | Spring Security |
+| **Language** | Java 25 LTS |
+| **Framework** | Spring Boot 4.1.0 (Spring Framework 7.0.8) |
+| **Persistence** | Hibernate ORM 7.4.1, Spring Data JPA |
+| **Serialization** | Jackson 3.1.4 (native defaults — no Jackson 2 compatibility bridge) |
+| **Security** | Spring Security 7.1.0 |
 | **Databases** | PostgreSQL, MySQL |
-| **Migration** | Flyway |
-| **Documentation** | OpenAPI 3.0 |
-| **Build Tool** | Gradle 7.6 |
-| **Containerization** | Docker |
+| **Migration** | Flyway (via `spring-boot-starter-flyway`) |
+| **Documentation** | OpenAPI 3 via springdoc-openapi 3.0.3 |
+| **Build Tool** | Gradle 8.14.5 |
+| **Testing** | JUnit 5, Testcontainers 2.x (MySQL + PostgreSQL), AssertJ, Mockito |
+| **Containerization** | Docker / Docker Compose |
 
 ## 📋 Development Roadmap
 
-### ✅ Completed Features
-- [x] Java 19 & Spring Boot 3.0.2 upgrade
-- [x] OpenAPI 3.0 documentation
-- [x] Multi-database configuration
+### ✅ Completed — Java 25 / Spring Boot 4 upgrade program
+- [x] Gradle wrapper 7.6 → 8.14.5
+- [x] Java 19 → 21 → 25 LTS
+- [x] JSON golden-file tests (Customer, Product, Inventory, PaymentHistoric) — request & response contracts
+- [x] Dual Testcontainers (MySQL + PostgreSQL simultaneously) with a captured SQL baseline
+- [x] Spring Boot 3.5.16 → 4.1.0 (Spring Framework 7, Jakarta EE 11, Spring Security 7, Hibernate 7 all came bundled)
+- [x] Jackson 2 → 3 migration, including turning off the `spring.jackson.use-jackson2-defaults` compatibility bridge
+- [x] Multi-database configuration (PostgreSQL + MySQL)
 - [x] Docker containerization
-- [x] Comprehensive unit tests
 - [x] Spring Security implementation
-- [x] Clean architecture refactoring
 
-### 🚧 In Progress
-- [ ] **Spring Security** *(Current Sprint)*
-- [ ] Redis caching layer
-- [ ] Java Records implementation
+### 🚧 Partially done
+- [ ] Java Records — started (`ErrorResponse`), not yet adopted across the other DTOs
 
 ### 🔮 Future Enhancements
-- [ ] Java 21 upgrade
+- [ ] Redis caching layer
 - [ ] Apache Kafka integration
 - [ ] MongoDB integration
-- [ ] TestContainers implementation
 - [ ] Scheduled processing
 - [ ] Modular monolith refactoring
 
 ## 🧪 Testing
 
+163 tests across unit, slice, and golden-file layers.
+
 ```bash
 # Run all tests
-./gradlew test
+./gradlew clean test
 
 # Run with coverage
-./gradlew test jacocoTestReport
+./gradlew clean test jacocoTestReport
 
 # Run specific test class
 ./gradlew test --tests CustomerControllerTest
+
+# Run only the golden-file regression suite (needs a Docker-compatible runtime for the SQL baseline test)
+./gradlew test --tests "br.com.ecommerce.golden.*"
 ```
+
+> The `DualDatabasePersistenceGoldenTest` spins up real MySQL and PostgreSQL containers via Testcontainers. It works with Docker or Podman (set `DOCKER_HOST` accordingly if using Podman).
 
 ## 📊 API Endpoints
 
-| Endpoint | Method | Description | Auth Required |
-|----------|--------|-------------|---------------|
-| `/customer` | GET | List all customers | ✅ |
-| `/customer/{cpf}` | GET | Get customer by CPF | ✅ |
-| `/customer` | POST | Create customer | ✅ |
-| `/customer` | PUT | Update customer | ✅ |
-| `/customer/{cpf}` | DELETE | Delete customer | ✅ |
-| `/parameter/**` | ALL | Parameter management | ❌ |
-| `/swagger-ui/**` | GET | API documentation | ❌ |
+| Resource | Method | Path | Auth Required |
+|----------|--------|------|----------------|
+| Customer | GET | `/customer` | ✅ |
+| Customer | GET | `/customer/{cpf}` | ✅ |
+| Customer | POST | `/customer` | ✅ |
+| Customer | PUT | `/customer` | ✅ |
+| Customer | DELETE | `/customer/{cpf}` | ✅ |
+| Product | GET | `/product` | ✅ |
+| Product | GET | `/product/{id}` | ✅ |
+| Product | POST | `/product` | ✅ |
+| Product | PUT | `/product` | ✅ |
+| Product | DELETE | `/product/{id}` | ✅ |
+| Inventory | GET | `/inventory` | ✅ |
+| Inventory | GET | `/inventory/{id}` | ✅ |
+| Inventory | POST | `/inventory` | ✅ |
+| Inventory | PUT | `/inventory` | ✅ |
+| Inventory | DELETE | `/inventory/{id}` | ✅ |
+| Payment Historic | GET | `/payment-historic` | ✅ |
+| Payment Historic | GET | `/payment-historic/{id}` | ✅ |
+| Payment Historic | POST | `/payment-historic` | ✅ |
+| Payment Historic | PUT | `/payment-historic` | ✅ |
+| Payment Historic | DELETE | `/payment-historic/{id}` | ✅ |
+| Parameter | GET | `/parameter/list` | ❌ |
+| Parameter | GET | `/parameter/sequence` | ❌ |
+| Docs | GET | `/swagger-ui/**` | ❌ |
 
 ## 🤝 Contributing
 
@@ -148,3 +176,4 @@ src/
 - [OpenAPI 3.0 Specification](https://springdoc.org/v2/)
 - [Spring Security Reference](https://docs.spring.io/spring-security/reference/)
 - [Flyway Documentation](https://flywaydb.org/documentation/)
+- [Testcontainers Documentation](https://testcontainers.com/)


### PR DESCRIPTION
## Summary

O README estava parado na época de Java 19 / Spring Boot 3.0.2 / Gradle 7.6 — bem antes do programa de upgrade (ondas 0-4) começar. Esta PR sincroniza com o estado real do serviço, verificado via `dependencyInsight` e leitura direta do código, não suposição.

- **Versões**: Java 25 LTS, Spring Boot 4.1.0 (Spring Framework 7.0.8, Hibernate ORM 7.4.1, Spring Security 7.1.0, Jackson 3.1.4 — nenhum desses aparecia no README antes, mesmo vindo junto com o Boot 4.1), Gradle 8.14.5.
- **Roadmap reescrito**: reflete o programa de upgrade concluído (golden files JSON, Testcontainers duplo com baseline SQL, migração Jackson 2→3 com a ponte de compatibilidade desligada). Java Records marcado como "parcial" porque `ErrorResponse` já é um `record`, mas não é padrão adotado nos outros DTOs — verifiquei no código antes de classificar.
- **Correções que já estavam erradas antes desta onda**:
  - `docker compose up` não funcionava como estava escrito — o `docker-compose.yml` fica em `src/main/resources/`, não na raiz.
  - `-Dspring.profiles.active=local` não corresponde a nenhum `application-local.yml` existente.
  - Tabela de endpoints só listava `/customer` e `/parameter`; faltavam `/product`, `/inventory`, `/payment-historic` inteiros (completei lendo os `@RequestMapping`/`@GetMapping` reais dos 5 controllers).
- **Seção de Testing nova**: explica os golden files + baseline SQL via Testcontainers duplo, com contagem real de 163 testes (confirmada via XML de uma rodada real).

## Test plan

- [x] Nenhuma mudança de código — só documentação, não requer rodar a suíte
- [x] Cada afirmação de versão conferida via `./gradlew dependencyInsight` contra o classpath real, não lida direto do `build.gradle`
- [x] Endpoints conferidos lendo as anotações `@RequestMapping`/`@GetMapping`/etc. dos controllers

🤖 Generated with [Claude Code](https://claude.com/claude-code)