### PR TITLE
fix: remove referencia orfa ao plugin/recipe OpenRewrite

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.7'
     id 'java'
     id 'jacoco'
-    id 'org.openrewrite.rewrite' version '7.37.0'
 }
 
 group = 'br.com'
@@ -21,9 +20,6 @@ configurations {
     }
 }
 
-rewrite {
-    activeRecipe("br.com.sicredi.rewrite.MigrateMockBeanToMockitoBean")
-}
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
rewrite.yml foi deletado (onda MockBean->MockitoBean ja concluida e permanente no codigo, recipe nao tem mais funcao). O build.gradle ainda referenciava o plugin e a activeRecipe apontando para um arquivo inexistente -- removido o bloco inteiro.

Build completo validado: 160/160 testes verdes.