### PR TITLE
docs: recria AGENTS.md e adiciona .github/prompts/ do modernization-kit

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,183 @@
+# AGENTS.md
+
+Regras para qualquer agente de IA trabalhando neste repositório durante o
+programa de upgrade Java 25 LTS + Spring Boot 4.1.
+
+Leia este arquivo por inteiro no início de toda sessão.
+
+---
+
+## Contexto obrigatório
+
+Antes de escrever qualquer código relacionado a Spring Boot 4, Spring
+Framework 7 ou Jackson 3, leia:
+
+- `context/target-versions.md`
+- `context/breaking-changes/` — o arquivo relevante à mudança em questão
+
+**Você não tem conhecimento confiável destas versões.** Elas são posteriores
+ao seu corte de treinamento. Assinaturas de método, nomes de pacote e
+propriedades de configuração que você "lembra" provavelmente estão erradas.
+
+---
+
+## Invioláveis
+
+1. **Uma onda por PR.** Nunca misture upgrade de Java com upgrade de Spring
+   no mesmo commit. Se o p99 degradar, é preciso saber qual dos dois causou.
+
+2. **Nunca altere lógica de negócio** no mesmo PR de um upgrade.
+
+3. **Se um golden file quebrar: PARE.** Reporte o diff exato, campo a campo.
+   **NUNCA atualize o arquivo `.json` para o teste passar.**
+   Um golden file quebrado significa que os bytes publicados em um tópico
+   Kafka mudaram. Isso é um incidente de contrato, não uma falha de teste.
+
+4. **Nunca edite um teste para fazê-lo passar.** Se um teste falha, ou o
+   código está errado, ou o teste revelou uma mudança de comportamento real.
+   Ambos os casos exigem decisão humana. Reporte e pare.
+
+5. **Não invente API.** Se você não tem certeza da assinatura de um método
+   de Boot 4 / Jackson 3 / Security 7, consulte `context/breaking-changes/`
+   ou busque na documentação oficial. Não adivinhe. Não "provavelmente é".
+
+6. **Rode o build antes de afirmar que terminou.** `mvn verify` (ou
+   `./gradlew build`). Sem exceção.
+
+7. **Não altere configuração do `ObjectMapper` / `JsonMapper`** para fazer
+   um teste passar. Essa configuração é contrato.
+
+8. **Nunca remova um teste.** Nunca adicione `@Disabled` / `@Ignore`.
+
+9. **Limite de tentativas: 3.** Se após três tentativas o build não passar,
+   pare, reporte o que tentou e o erro atual. Não continue tentando variações.
+
+10. **Antes de qualquer onda — inclusive as de toolchain — rode o build uma
+    vez para confirmar baseline verde.** Uma onda que não muda versão de
+    dependência ainda pode expor falha pré-existente (infraestrutura fora
+    do ar, teste mal escopado). Sem baseline confirmado, toda falha
+    pós-onda vira suspeita da onda, mesmo quando não é.
+
+11. **Quando um teste falha por infraestrutura ausente (banco, fila),
+    primeiro pergunte se o teste deveria depender daquela infraestrutura.**
+    - Se o teste verifica lógica de negócio, regra de segurança, ou
+      contrato HTTP — **não deveria**. `@SpringBootTest` genérico sobe o
+      contexto inteiro por padrão, incluindo `@Configuration` de
+      persistência que o teste não usa. Reduza o escopo: `@WebMvcTest`
+      com as classes de controller explícitas, `@MockBean` para cada
+      serviço injetado, `@Import` explícito de configs de segurança
+      customizadas (elas não entram automaticamente no component scan
+      reduzido do slice).
+    - Se o teste verifica comportamento real de persistência (dialeto,
+      schema, query gerada) — **deveria**. A correção aqui é
+      Testcontainers, nunca remover a dependência.
+    - Nunca "resolva" isso convertendo o teste em mock do banco quando o
+      propósito do teste era validar o banco de verdade.
+
+12. **Quando um warning de build sugerir uma flag de diagnóstico** (ex:
+    "Recompile with -Xlint:deprecation for details", "Run with
+    --stacktrace", "use --warning-mode all") **aplique-a automaticamente
+    para capturar o detalhe — não pare no warning genérico.** Procedimento:
+    - Prefira a via menos invasiva (flag de linha de comando) quando o
+      build tool suportar passthrough direto.
+    - Se só for possível via edição do arquivo de build (caso comum em
+      Gradle, que não tem passthrough universal para `compilerArgs`),
+      aplique a edição, capture o output completo, e **reverta a edição
+      imediatamente depois** — antes de qualquer commit. A alteração
+      diagnóstica nunca deve aparecer no diff da onda.
+    - Classifique cada warning revelado em uma de três categorias:
+      **(a) relacionado à onda atual** — resolve agora, dentro do escopo;
+      **(b) pré-existente, não relacionado ao upgrade** — registra em
+      `nao_determinado`/`riscos` da ficha do serviço, não resolve na
+      mesma onda a menos que seja trivial e sem risco;
+      **(c) relacionado a onda futura** — registra em
+      `context/breaking-changes/` ou na ficha do serviço, não resolve
+      agora, mas o diário deve mencionar que já foi previsto.
+    - Nunca ignore o warning original só porque o build passou. "Verde"
+      não significa "sem achado relevante" — a Onda -1/3.5.x existe
+      justamente para revelar esses achados com antecedência.
+
+13. **`--rerun` não é uma flag válida do Gradle — é `--rerun-tasks`.**
+    O parser do Gradle aceita prefixos ambíguos sem sempre avisar, então
+    `--rerun` pode ser silenciosamente ignorado em vez de rejeitado, e o
+    build reporta `up-to-date` mesmo quando a intenção era forçar
+    reexecução. **Use sempre o nome completo `--rerun-tasks`, ou prefira
+    `clean` antes de builds cuja verificação precisa ser inequívoca** —
+    `clean` elimina qualquer artefato de cache, tornando `up-to-date`
+    fisicamente impossível. A própria ferramenta de verificação pode
+    mentir por engano de sintaxe, não só por cache — trate flags de
+    verificação com o mesmo ceticismo que resultados de teste.
+
+14. **No Windows, `Out-File -Encoding utf8` insere BOM (`EF BB BF`) no
+    início do arquivo — quebra parsers JSON silenciosamente.** Sintoma:
+    `JSONException`/`FileNotFoundException` estranho ao ler um golden file
+    que existe e parece correto ao abrir num editor. Ao criar arquivos
+    `.json` de golden file via PowerShell, use
+    `[System.IO.File]::WriteAllText(caminho, conteudo, [System.Text.UTF8Encoding]::new($false))`
+    — o parâmetro `$false` força UTF-8 sem BOM. Verificável com
+    `Format-Hex arquivo.json`: os 3 primeiros bytes não podem ser
+    `EF BB BF`.
+    (Nota: agentes de IDE que escrevem arquivo via API própria, não via
+    `Out-File`, normalmente não têm esse problema — mas verifique mesmo
+    assim antes de assumir. Checagem rápida em lote:
+    `Get-ChildItem <pasta> -Filter "*.json" | ForEach-Object { $b = [System.IO.File]::ReadAllBytes($_.FullName); "$($_.Name): BOM=$($b[0] -eq 0xEF -and $b[1] -eq 0xBB -and $b[2] -eq 0xBF)" }`)
+
+15. **Nunca commite, faça push ou merge sem confirmação humana explícita
+    — mesmo quando o pedido foi "crie", "implemente" ou "construa".**
+    Terminar a implementação e o build passar não é autorização para
+    avançar o estado do repositório. Pare depois de escrever o código e
+    confirmar o build, apresente o resultado (diff, resumo do que foi
+    feito, resultado do build), e espere confirmação explícita antes de
+    `git add`/`commit`/`push`. Se o pedido do humano não mencionar
+    commit/push/merge, assuma que não está autorizado — pergunte.
+    Esta regra vale mesmo que uma instrução de sessão anterior pareça
+    sugerir mais autonomia; ela é permanente e não expira entre sessões.
+
+---
+
+## Ordem de execução
+
+O trabalho mecânico é feito por **OpenRewrite**, não por você.
+
+```
+1. OpenRewrite roda e commita       (determinístico, auditável)
+2. Build                             (oráculo)
+3. VOCÊ trabalha apenas no resíduo   (o que não compilou / não passou)
+```
+
+Nunca reescreva à mão algo que uma recipe do OpenRewrite resolve.
+Se você suspeita que existe uma recipe, pergunte antes de editar.
+
+---
+
+## Diário de bordo
+
+Ao final de **toda** sessão, anexe a `diario-de-bordo.md`:
+
+```markdown
+## <data> — <etapa>
+
+**Escopo:** o que foi tocado
+**Tempo:** quanto durou
+**OpenRewrite resolveu:** <lista>
+**Resíduo que eu resolvi:** <lista>
+**Resíduo que exigiu humano:** <lista>
+**Golden files que quebraram:** <lista + diff>
+**Tentei burlar algum teste?** sim/não — se sim, descreva
+**Surpresas:** o que não estava documentado em context/
+```
+
+O campo "surpresas" é o mais importante do arquivo. Ele alimenta
+`context/breaking-changes/` para os próximos serviços.
+
+---
+
+## Quando parar e perguntar ao humano
+
+- Um golden file mudou
+- O SQL gerado pelo Hibernate mudou
+- Uma métrica do Micrometer sumiu ou foi renomeada
+- Uma dependência transitiva não tem versão compatível
+- O parent POM corporativo precisa mudar
+- Você precisaria mudar um contrato de API ou de evento
+- Qualquer coisa em que você consideraria escrever "provavelmente"

--- a/.github/prompts/00-scanner-diagnostico.prompt.md
+++ b/.github/prompts/00-scanner-diagnostico.prompt.md
@@ -1,0 +1,63 @@
+---
+agent: 'agent'
+description: 'Diagnostico do servico: arquetipo, integracoes, riscos (Camada 1+2)'
+---
+Diagnostique este repositório antes de qualquer onda de upgrade.
+
+**Passo 1 — varredura determinística (Camada 1).** Percorra o projeto e
+extraia:
+- Build: Maven ou Gradle, versão do Boot, versão do Java, versão do
+  Gradle wrapper
+- Stack web: `starter-web` vs `starter-webflux` vs nenhum
+- Integrações: procure por Kafka, Oracle, Postgres, MySQL, Mongo, AWS
+  SDK, Redis nas dependências declaradas
+- Sinais de risco: conte imports `javax.persistence`/`javax.servlet`/
+  `javax.validation`/`javax.annotation`/`javax.transaction` (relevantes
+  para Jakarta EE — **não** conte `javax.sql`/`javax.crypto`/`javax.net`/
+  `javax.management`, que são do JDK e nunca migram)
+- Arquivos com múltiplos `@Bean` retornando `DataSource` (sinal de
+  multi-datasource)
+- `new ObjectMapper()` fora de `@Configuration`
+- `embedded-kafka`, Mongo embarcado, ou H2 em escopo de teste
+
+**Passo 2 — interpretação.** Com os fatos brutos do passo 1, escreva
+um resumo em prosa: qual o arquétipo deste serviço (ex:
+`mvc-jpa-multi-datasource`, `webflux-kafka`, `mvc-jpa-mongo`), quais
+integrações reais existem, quais riscos merecem atenção antes de
+migrar.
+
+**Regras:**
+- Toda afirmação cita evidência (arquivo:linha). Se não tem certeza,
+  marque como "não determinado" — não invente.
+- Não infira criticidade de negócio — isso vem de um humano.
+- `@Primary`/`@Qualifier` são mecanismo de resolução do Spring, não
+  indicam importância de negócio — não interprete como tal.
+
+**Passo 3 — determine o PRÓXIMO PASSO REAL, não uma lista genérica.**
+Percorra esta checklist NA ORDEM e pare no primeiro item que ainda não
+está feito — esse é o comando a recomendar. Não recomende uma onda que
+já está concluída, mesmo que ela exista na sequência.
+
+| Onda | Já está feito se... | Comando |
+|---|---|---|
+| 0 | `gradle-wrapper.properties` já aponta para >= 8.14 | `/01-onda-0-gradle` |
+| -1 | Boot já está numa versão 4.x (não precisa mais de ponte 3.x) | `/02-onda-neg1-boot-ponte` |
+| -1b | Nenhum `@MockBean`/`@SpyBean` encontrado no projeto | `/03-onda-neg1b-mockbean` |
+| 1 | Toolchain Java já declarado >= 21 | `/04-onda-1-java-minimo` |
+| 1b | Toolchain Java já declarado = 25 | `/05-onda-1b-java-lts` |
+| 2a | Existe pelo menos um teste `@JsonTest`/`JacksonTester` com round-trip para os DTOs de request | `/06-onda-2a-golden-files` |
+| 2b | Existe teste `@Testcontainers` real (não embedded) para cada integração de dados encontrada | `/07-onda-2b-testcontainers` |
+| 3 | Boot já está em 4.1.x (não só 4.0.x) | `/08-onda-3-boot-major` |
+| 4 | `spring.jackson.use-jackson2-defaults` está ausente OU explicitamente `false` | `/09-onda-4-jackson-nativo` |
+
+Se TODOS os itens já estiverem feitos, diga isso claramente — não
+invente uma onda para recomendar. "Este serviço já está no destino
+(Java 25 + Boot 4.1 + Jackson 3 nativo); nenhuma onda pendente" é uma
+resposta válida e esperada, não uma falha do diagnóstico.
+
+**Saída:** um resumo estruturado (pode ser um comentário no chat, não
+precisa criar arquivo) com: arquétipo, build atual, integrações
+encontradas, riscos identificados, **e o único próximo comando
+recomendado** (não uma lista de possibilidades) — resultado do Passo 3.
+
+Não edite nenhum arquivo neste passo — é só leitura e diagnóstico.

--- a/.github/prompts/01-onda-0-gradle.prompt.md
+++ b/.github/prompts/01-onda-0-gradle.prompt.md
@@ -1,0 +1,41 @@
+---
+agent: 'agent'
+description: 'Onda 0: bump do Gradle wrapper para versao que suporta o plugin do Boot 4'
+---
+Execute a Onda 0: bump do Gradle wrapper.
+
+**Passo 1.** Rode `./gradlew clean build` (ou `mvnw clean verify` se for
+Maven — se for Maven, pare e reporte, essa onda é específica de Gradle)
+e confirme baseline verde antes de tocar em qualquer coisa. Se o
+baseline já estiver quebrado, PARE e reporte — não prossiga.
+
+**Passo 2.** Atualize `gradle/wrapper/gradle-wrapper.properties` para
+Gradle 8.14 ou mais recente (o plugin do Spring Boot 4 exige no mínimo
+8.14). Comando:
+```
+./gradlew wrapper --gradle-version 8.14 --distribution-type bin
+```
+No Windows, a primeira execução pode gerar erro de terminal por
+autossobrescrita do `.bat` — se aparecer erro após "BUILD SUCCESSFUL",
+rode `./gradlew --version` limpo para confirmar se a versão nova
+realmente aplicou antes de assumir falha.
+
+**Passo 3.** Rode `./gradlew clean build` de novo (nunca `--rerun` —
+essa flag não existe no Gradle, é `--rerun-tasks`, e pode ser aceita
+silenciosamente sem forçar nada).
+
+**Se algum teste falhar nesta onda:** antes de assumir que a onda
+causou, pergunte se o teste deveria depender do que falhou. Testes de
+regra de negócio/segurança/HTTP que falham por infraestrutura ausente
+(Docker parado, por exemplo) geralmente são teste mal escopado
+pré-existente (`@SpringBootTest` genérico demais), não causado por
+esta onda — reduza o escopo (`@WebMvcTest` + `@MockBean`/`@MockitoBean`
+dos serviços injetados + `@Import` de qualquer config de segurança
+customizada) em vez de assumir regressão.
+
+**Pare antes de commitar.** Reporte: build antes/depois, versão do
+Gradle antes/depois, qualquer teste que precisou de ajuste e por quê.
+Aguarde confirmação para `git add`/`commit`/`push`.
+
+---
+**Próximo passo, após o merge confirmado:** `/02-onda-neg1-boot-ponte`

--- a/.github/prompts/02-onda-neg1-boot-ponte.prompt.md
+++ b/.github/prompts/02-onda-neg1-boot-ponte.prompt.md
@@ -1,0 +1,40 @@
+---
+agent: 'agent'
+description: 'Onda -1: sobe ate o ultimo patch da linha atual do Spring Boot (ponte)'
+---
+Execute a Onda -1: ponte até o último patch da linha atual do Spring Boot.
+
+**Passo 1.** Confirme baseline verde com `clean build` antes de tocar
+em qualquer coisa.
+
+**Passo 2.** Descubra qual é o último patch da linha atual (ex: se o
+projeto está em `3.3.0`, descubra o último `3.5.x` publicado —
+consulte o `maven-metadata.xml` do Maven Central, não suponha o
+número). Atualize a versão do plugin/BOM do Spring Boot para esse
+patch.
+
+**Passo 3.** Rode `clean build --warning-mode all` (não só `clean
+build`) — o objetivo desta onda é justamente capturar os warnings de
+depreciação que preveem o resíduo da onda seguinte (o salto major).
+Liste os warnings encontrados no relatório final, mesmo os que não
+quebram nada agora.
+
+**Passo 4.** Resolva achados **pré-existentes** revelados pelos
+warnings (ex: método de senha inseguro, API depreciada há anos) como
+commits separados, claramente rotulados como "achado pré-existente,
+não causado por esta onda" — não misture com a mudança de versão em
+si.
+
+**Se sobrar dúvida sobre alguma API nova:** não invente assinatura.
+Busque na documentação oficial da versão exata, ou inspecione o jar
+diretamente se o compilador reclamar de símbolo que sumiu sem
+explicação na doc.
+
+**Pare antes de commitar.** Reporte: versão antes/depois, warnings
+capturados, achados pré-existentes resolvidos (se houver). Aguarde
+confirmação.
+
+---
+**Próximo passo, após o merge confirmado:** `/03-onda-neg1b-mockbean` se
+o serviço usar `@MockBean`/`@SpyBean` (o scanner já deveria ter
+indicado isso); senão, pule direto para `/04-onda-1-java-minimo`.

--- a/.github/prompts/03-onda-neg1b-mockbean.prompt.md
+++ b/.github/prompts/03-onda-neg1b-mockbean.prompt.md
@@ -1,0 +1,66 @@
+---
+agent: 'agent'
+description: 'Onda -1b: migra @MockBean/@SpyBean para @MockitoBean/@MockitoSpyBean'
+---
+Execute a Onda -1b: migração de `@MockBean`/`@SpyBean` (deprecados
+desde Boot 3.4.0, remoção prevista para 4.0.0) para
+`@MockitoBean`/`@MockitoSpyBean`.
+
+**Passo 1.** Confirme baseline verde com `clean build`.
+
+**Passo 2.** Verifique se o repositório usa `@MockBean` ou `@SpyBean`
+em algum teste. Se não usar nenhum, reporte isso e pare — onda não se
+aplica a este serviço.
+
+**Passo 3.** Se `build.gradle` ainda não tiver o plugin do
+OpenRewrite, adicione:
+```groovy
+plugins {
+    id 'org.openrewrite.rewrite' version '6.16.3'
+}
+```
+
+**Passo 4.** Crie (se ainda não existir) `rewrite.yml` na raiz do
+projeto com este conteúdo exato:
+```yaml
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: br.com.empresa.rewrite.MigrateMockBeanToMockitoBean
+displayName: Migrar MockBean/SpyBean para MockitoBean/MockitoSpyBean
+recipeList:
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.boot.test.mock.mockito.MockBean
+      newFullyQualifiedTypeName: org.springframework.test.context.bean.override.mockito.MockitoBean
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.boot.test.mock.mockito.SpyBean
+      newFullyQualifiedTypeName: org.springframework.test.context.bean.override.mockito.MockitoSpyBean
+```
+Ajuste `br.com.empresa` para o pacote real da sua organização se
+quiser manter convenção — não é obrigatório, o nome da recipe é livre.
+
+**Passo 5.** Ative a recipe:
+```groovy
+rewrite {
+    activeRecipe("br.com.empresa.rewrite.MigrateMockBeanToMockitoBean")
+}
+```
+
+**Passo 6.** Rode `./gradlew rewriteDryRun` primeiro, leia o relatório
+gerado. Se o diff parecer correto (só troca de import + anotação),
+rode `./gradlew rewriteRun` para aplicar de verdade.
+
+**Passo 7.** Rode a suíte **inteira** (`clean build`), não só os
+arquivos tocados — há diferença comportamental documentada entre as
+duas anotações em cenários raros; só a suíte completa garante que não
+apareceu aqui.
+
+**Nota de licença:** esta recipe usa só `org.openrewrite.java.ChangeType`
+(núcleo do OpenRewrite, Apache 2.0) — não depende do módulo
+`rewrite-spring`, que tem pendência de licença (Moderne Source
+Available) ainda não confirmada juridicamente para uso comercial.
+
+**Pare antes de commitar.** Reporte o diff e o resultado do build
+completo. Aguarde confirmação.
+
+---
+**Próximo passo, após o merge confirmado:** `/04-onda-1-java-minimo`

--- a/.github/prompts/04-onda-1-java-minimo.prompt.md
+++ b/.github/prompts/04-onda-1-java-minimo.prompt.md
@@ -1,0 +1,46 @@
+---
+agent: 'agent'
+description: 'Onda 1: Java para a versao minima exigida pelo Boot 4 (toolchain hermetico)'
+---
+Execute a Onda 1: sobe o Java para a versão mínima exigida pelo Spring
+Boot 4 (21), usando toolchain hermético do Gradle — não depende de
+`JAVA_HOME`/PATH/IDE de cada máquina.
+
+**Passo 1.** Confirme baseline verde com `clean build`.
+
+**Passo 2.** Em `settings.gradle`, adicione:
+```groovy
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
+}
+```
+
+**Passo 3.** Em `build.gradle`, **substitua** `sourceCompatibility`
+(se existir) pelo bloco:
+```groovy
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+```
+
+**Passo 4.** Rode `clean build --info | grep "Compiling with toolchain"`
+(ou equivalente `Select-String` no PowerShell) — confirme qual JDK
+compilou de verdade. Se o Gradle precisar baixar um JDK novo (via
+Foojay Disco API), isso indica que a rede desta máquina permite acesso
+a `api.foojay.io` — reporte se baixou ou só detectou um já instalado,
+é informação relevante para confirmar com o time de infra se outras
+máquinas/CI têm o mesmo acesso.
+
+**Se aparecer erro do Lombok** (`ExceptionInInitializerError`,
+menção a `sun.misc.Unsafe`/`lombok.permit.Permit`): é incompatibilidade
+de versão do Lombok com o JDK, não bug seu. Confira a versão declarada
+— versões antigas (< 1.18.42) não suportam Java 21+ corretamente em
+alguns casos. Atualize para uma versão mais recente do Lombok.
+
+**Pare antes de commitar.** Reporte o resultado do build e se houve
+download de JDK. Aguarde confirmação.
+
+---
+**Próximo passo, após o merge confirmado:** `/05-onda-1b-java-lts`

--- a/.github/prompts/05-onda-1b-java-lts.prompt.md
+++ b/.github/prompts/05-onda-1b-java-lts.prompt.md
@@ -1,0 +1,41 @@
+---
+agent: 'agent'
+description: 'Onda 1b: Java para o LTS alvo final (25)'
+---
+Execute a Onda 1b: sobe o Java do mínimo intermediário (21) para o LTS
+alvo final (25).
+
+**Passo 1.** Confirme baseline verde com `clean build`.
+
+**Passo 2.** Em `build.gradle`, altere:
+```groovy
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+```
+
+**Passo 3.** Rode `clean build`. **Diferente da Onda 1**, é provável
+que não exista JDK 25 pré-instalado na máquina — espere o Gradle
+baixar de verdade via Foojay Disco API. Se falhar por rede bloqueada,
+reporte claramente — é achado de infraestrutura, não bug de código.
+
+**Se aparecer `ExceptionInInitializerError` do Lombok:** confirme a
+versão declarada. Lombok < 1.18.42 não compila sob Java 25. Atualize
+para 1.18.42 ou mais recente (validado: 1.18.42 e 1.18.46 funcionam).
+As duas ocorrências (`compileOnly` e `annotationProcessor`) precisam
+estar na mesma versão.
+
+**Nota:** há bug residual conhecido, não totalmente corrigido, em
+combinações `@Value`/`@Builder` + inicialização de construtor default
+sob JDK 25 (`projectlombok/lombok#3981`). Se aparecer erro de
+"variable not initialized in default constructor" mesmo com Lombok
+atualizado, é isso — reporte e não tente forçar workaround sem
+confirmar com um humano.
+
+**Pare antes de commitar.** Reporte o resultado do build, se baixou
+JDK, e a versão final do Lombok. Aguarde confirmação.
+
+---
+**Próximo passo, após o merge confirmado:** `/06-onda-2a-golden-files`

--- a/.github/prompts/06-onda-2a-golden-files.prompt.md
+++ b/.github/prompts/06-onda-2a-golden-files.prompt.md
@@ -1,0 +1,53 @@
+---
+agent: 'agent'
+description: 'Onda 2a: golden files de serializacao (round-trip) antes do Boot major'
+---
+Execute a Onda 2a: rede de segurança de serialização, obrigatória
+antes de qualquer tentativa de subir o Spring Boot major.
+
+**Passo 1.** Identifique os DTOs em risco: classes usadas como
+`@RequestBody` em endpoints `POST`/`PUT`, especialmente as anotadas
+`@Data @Builder` (Lombok) sem nenhuma anotação Jackson explícita
+(`@JsonCreator`, `@Jacksonized`, etc.) — esse padrão é o que mais
+frequentemente quebra na migração para Jackson 3.
+
+**Passo 2.** Para cada DTO identificado, escreva um teste `@JsonTest`
+com `JacksonTester`, cobrindo **sempre os dois sentidos**:
+```java
+@JsonTest
+class XGoldenTest {
+    @Autowired private JacksonTester<X> json;
+
+    @Test
+    void serializacao_naoMudou() throws Exception {
+        assertThat(json.write(fixture())).isEqualToJson(new ClassPathResource("golden/x.json"));
+    }
+
+    @Test
+    void roundTrip_preservaTiposEValores() throws Exception {
+        var jsonContent = json.write(fixture()).getJson();
+        var desserializado = json.parseObject(jsonContent);
+        // asserts campo a campo -- para BigDecimal use isEqualByComparingTo, nao isEqualTo
+    }
+}
+```
+**O teste de round-trip não é opcional.** Ele existe porque há bug
+real e confirmado no Jackson 3 (creator implícito quebrado para
+`@Data @Builder`) que só quebra na desserialização — a serialização
+continua idêntica. Um golden file sem round-trip não detecta isso.
+
+**Passo 3.** Nunca chute o JSON esperado. Escreva primeiro um teste de
+descoberta (imprime o JSON real gerado), rode, confirme o formato real
+(datas, decimais), só então fixe o arquivo `golden/x.json` definitivo
+e apague o teste de descoberta.
+
+**No Windows, ao criar os arquivos `.json`:** não use `Out-File
+-Encoding utf8` do PowerShell — insere BOM e quebra o parser JSON.
+Use `[System.IO.File]::WriteAllText(caminho, conteudo,
+[System.Text.UTF8Encoding]::new($false))`.
+
+**Pare antes de commitar.** Reporte quais DTOs foram cobertos e o
+resultado do build. Aguarde confirmação.
+
+---
+**Próximo passo, após o merge confirmado:** `/07-onda-2b-testcontainers`

--- a/.github/prompts/07-onda-2b-testcontainers.prompt.md
+++ b/.github/prompts/07-onda-2b-testcontainers.prompt.md
@@ -1,0 +1,56 @@
+---
+agent: 'agent'
+description: 'Onda 2b: Testcontainers real + baseline SQL + guarda de N+1'
+---
+Execute a Onda 2b: rede de segurança de persistência, obrigatória
+antes de qualquer tentativa de subir o Spring Boot major.
+
+**Passo 1.** Identifique as integrações de dados reais deste serviço
+(Postgres, MySQL, Mongo — via `@Configuration` que constrói
+`DataSource`/`EntityManagerFactory`). Se usar `embedded-kafka`, H2 ou
+Mongo embarcado em teste, isso precisa ser substituído — eles mascaram
+diferença de dialeto/driver real.
+
+**Passo 2.** Escreva um teste de integração com Testcontainers real
+para cada banco, cobrindo o caminho de produção (grava e lê via os
+mesmos `Repository`/`Config` que a aplicação usa):
+```java
+@Testcontainers
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+class XPersistenceTest {
+    @Container
+    static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16");
+    // ... outros containers conforme integracoes reais
+
+    @DynamicPropertySource
+    static void props(DynamicPropertyRegistry registry) {
+        // ... jdbc-url/username/password/driverClassName por datasource
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "create"); // NUNCA create-drop
+    }
+}
+```
+
+**⚠️ `ddl-auto=create-drop` causa race condition no shutdown**
+(Hibernate tenta `DROP TABLE` no container já derrubado pelo JUnit —
+2 timeouts de 30s por execução, sem quebrar o build, mas custando
+tempo real). Use sempre `create`.
+
+**Passo 3.** Capture o SQL real gerado como baseline versionado — não
+só "passou". Registre um `StatementInspector` via
+`spring.jpa.properties.hibernate.session_factory.statement_inspector`
+no mesmo `@DynamicPropertySource`, compare contra arquivo
+`.sql` versionado. Isso é o baseline pré-Hibernate-7.
+
+**Passo 4.** Adicione guarda de N+1: conte SELECT/INSERT por operação
+com `assertThat(count).isEqualTo(N)` — contagem exata, não limite
+superior. **Se a entidade tiver `@Id` atribuído manualmente (sem
+`@GeneratedValue`), espere 1 SELECT a mais que o intuitivo** — o
+`save()` do Spring Data chama `merge()`, não `persist()`, porque não
+sabe se o registro é novo sem consultar. Não é bug.
+
+**Pare antes de commitar.** Reporte quais integrações foram cobertas e
+o resultado do build. Aguarde confirmação.
+
+---
+**Próximo passo, após o merge confirmado:** `/08-onda-3-boot-major`
+(só depois de 06 E 07 estarem mergeados — os dois são pré-requisito).

--- a/.github/prompts/08-onda-3-boot-major.prompt.md
+++ b/.github/prompts/08-onda-3-boot-major.prompt.md
@@ -1,0 +1,82 @@
+---
+agent: 'agent'
+description: 'Onda 3: salto para Spring Boot 4.1 (a onda principal)'
+---
+Execute a Onda 3: salto para Spring Boot 4.1.
+
+**⚠️ Pré-requisito não negociável:** confirme que as Ondas 2a e 2b (golden
+files + Testcontainers) já existem e passam. Sem isso, PARE e reporte
+— não prossiga sem rede de segurança.
+
+**Passo 1.** Confirme baseline verde com `clean build`.
+
+**Passo 2.** Adicione temporariamente ao `build.gradle`:
+```groovy
+rewrite {
+    activeRecipe("org.openrewrite.java.spring.boot4.UpgradeSpringBoot_4_0")
+}
+dependencies {
+    rewrite("org.openrewrite.recipe:rewrite-spring:latest.release")
+}
+```
+**Nota de licença:** `rewrite-spring` está sob Moderne Source
+Available License, não Apache. Confirme com seu jurídico/compliance
+antes de aplicar isto em qualquer serviço real — não assuma aprovado
+só por este prompt existir.
+
+**Passo 3.** Rode `./gradlew rewriteRun` (não dryRun — já é a
+aplicação real). A recipe provavelmente mira a última minor conhecida
+por ela (ex: 4.0.7), não a mais recente estável — depois de rodar,
+confirme a versão realmente estável via `maven-metadata.xml` do Maven
+Central e ajuste manualmente para ela.
+
+**Passo 4.** Confira a versão do Lombok após a recipe rodar — ela pode
+ter mudado (subido ou descido). Não assuma, verifique.
+
+**Passo 5.** Remova a dependência `rewrite-spring` e a `activeRecipe`
+temporária; restaure a recipe própria (`MigrateMockBeanToMockitoBean`,
+se existir) ou remova o bloco `rewrite` inteiro se não precisar mais.
+Fixe a versão do plugin `org.openrewrite.rewrite` na versão real
+resolvida (não deixe `latest.release` permanente — quebra
+reprodutibilidade).
+
+**Passo 6.** Adicione a ponte de compatibilidade em
+`application.yml`/`application-test.yml`:
+```yaml
+spring:
+  jackson:
+    use-jackson2-defaults: true
+```
+(desliga isso é a Onda 4, separada — não desligue aqui)
+
+**Passo 7.** Compile e resolva o resíduo. Esperado:
+- `MigrateToModularStarters` (maior volume): starters reorganizados
+- Pacotes movidos sem aviso em release note — se o compilador reclamar
+  de símbolo que sumiu e a doc não explicar, inspecione o jar da nova
+  versão diretamente
+- Property renomeada (`server.error.include-stacktrace` pode virar
+  `spring.web.error.include-stacktrace`)
+- `WWW-Authenticate` ganha `, charset="UTF-8"` (Security 7) — ajuste a
+  asserção do teste, não a aplicação
+
+**Passo 8. CRÍTICO — se golden files quebrarem no round-trip (não na
+serialização):** é provável que seja o bug real e confirmado do
+Jackson 3 em detecção de creator implícito para `@Data @Builder` sem
+anotação explícita (`InvalidDefinitionException: no Creators, like
+default constructor, exist`). A ponte `use-jackson2-defaults` **não
+cobre isso**. PARE, reporte o diff exato, e proponha a correção — não
+aplique sozinho sem confirmação:
+```java
+@Data
+@Builder
+@NoArgsConstructor    // as duas juntas, sempre
+@AllArgsConstructor   // uma sozinha quebra a compilacao do @Builder
+public class MeuDto { ... }
+```
+
+**Pare antes de commitar.** Reporte: diff completo, resultado do
+build, cada achado classificado (mecânico vs. quebra de contrato vs.
+pré-existente). Aguarde confirmação.
+
+---
+**Próximo passo, após o merge confirmado:** `/09-onda-4-jackson-nativo`

--- a/.github/prompts/09-onda-4-jackson-nativo.prompt.md
+++ b/.github/prompts/09-onda-4-jackson-nativo.prompt.md
@@ -1,0 +1,52 @@
+---
+agent: 'agent'
+description: 'Onda 4: desliga a ponte Jackson 2, expoe comportamento nativo do Jackson 3'
+---
+Execute a Onda 4: desliga a ponte de compatibilidade do Jackson,
+expondo o comportamento nativo do Jackson 3.
+
+**Passo 1.** Confirme baseline verde com `clean build`.
+
+**Passo 2.** Em `application.yml` e `application-test.yml`, mude:
+```yaml
+spring:
+  jackson:
+    use-jackson2-defaults: false
+```
+Não apague a linha — deixa explícito que foi desligado de propósito.
+
+**Passo 3.** Rode a suíte inteira (`clean build`).
+
+**Passo 4. Se algum golden file quebrar, isso pode ser o RESULTADO
+ESPERADO desta onda** — o objetivo é justamente expor o comportamento
+real do Jackson 3, antes mascarado pela ponte. Mesmo assim: NÃO edite
+o `.json`/`.sql`/asserções para forçar passar. Reporte o diff exato
+(esperado vs. capturado) para decisão humana sobre aceitar os novos
+bytes como novo contrato.
+
+**Passo 5.** Se nada quebrar, não aceite isso de bandeja — confirme
+por que. A ponte controla apenas 4 features:
+`WRITE_DATES_AS_TIMESTAMPS`, `WRITE_DURATIONS_AS_TIMESTAMPS`,
+`FAIL_ON_UNKNOWN_PROPERTIES`, `DEFAULT_VIEW_INCLUSION`. Verifique se
+os testes existentes realmente exercitam essas 4 (ex: existe teste
+que envia campo JSON desconhecido? Existe `@JsonView` em uso?). Se
+não existir teste para `FAIL_ON_UNKNOWN_PROPERTIES`, essa é uma
+lacuna de cobertura real — escreva um teste que envie um campo extra
+no JSON e confirme o comportamento (ignora ou lança exceção) antes de
+considerar a onda concluída.
+
+**⚠️ `FAIL_ON_UNKNOWN_PROPERTIES` é sensível a patch version do Boot
+4.0.x** — há issue real do próprio Spring Boot
+(`spring-projects/spring-boot#49951`) mostrando comportamento oposto
+entre patches próximos. Não assuma que o resultado deste serviço vale
+para outro sem teste próprio.
+
+**Pare antes de commitar.** Reporte o resultado da suíte completa e,
+se nada quebrou, a confirmação de que as 4 features foram de fato
+exercitadas por teste real. Aguarde confirmação.
+
+---
+**Próximo passo:** esta é a última onda da sequência principal. Se
+tudo passou, o serviço está no destino (Java 25 LTS + Boot 4.1 +
+Jackson 3 nativo). Para migrar outro serviço, comece de novo por
+`/00-scanner-diagnostico` nele.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,183 @@
+# AGENTS.md
+
+Regras para qualquer agente de IA trabalhando neste repositório durante o
+programa de upgrade Java 25 LTS + Spring Boot 4.1.
+
+Leia este arquivo por inteiro no início de toda sessão.
+
+---
+
+## Contexto obrigatório
+
+Antes de escrever qualquer código relacionado a Spring Boot 4, Spring
+Framework 7 ou Jackson 3, leia:
+
+- `context/target-versions.md`
+- `context/breaking-changes/` — o arquivo relevante à mudança em questão
+
+**Você não tem conhecimento confiável destas versões.** Elas são posteriores
+ao seu corte de treinamento. Assinaturas de método, nomes de pacote e
+propriedades de configuração que você "lembra" provavelmente estão erradas.
+
+---
+
+## Invioláveis
+
+1. **Uma onda por PR.** Nunca misture upgrade de Java com upgrade de Spring
+   no mesmo commit. Se o p99 degradar, é preciso saber qual dos dois causou.
+
+2. **Nunca altere lógica de negócio** no mesmo PR de um upgrade.
+
+3. **Se um golden file quebrar: PARE.** Reporte o diff exato, campo a campo.
+   **NUNCA atualize o arquivo `.json` para o teste passar.**
+   Um golden file quebrado significa que os bytes publicados em um tópico
+   Kafka mudaram. Isso é um incidente de contrato, não uma falha de teste.
+
+4. **Nunca edite um teste para fazê-lo passar.** Se um teste falha, ou o
+   código está errado, ou o teste revelou uma mudança de comportamento real.
+   Ambos os casos exigem decisão humana. Reporte e pare.
+
+5. **Não invente API.** Se você não tem certeza da assinatura de um método
+   de Boot 4 / Jackson 3 / Security 7, consulte `context/breaking-changes/`
+   ou busque na documentação oficial. Não adivinhe. Não "provavelmente é".
+
+6. **Rode o build antes de afirmar que terminou.** `mvn verify` (ou
+   `./gradlew build`). Sem exceção.
+
+7. **Não altere configuração do `ObjectMapper` / `JsonMapper`** para fazer
+   um teste passar. Essa configuração é contrato.
+
+8. **Nunca remova um teste.** Nunca adicione `@Disabled` / `@Ignore`.
+
+9. **Limite de tentativas: 3.** Se após três tentativas o build não passar,
+   pare, reporte o que tentou e o erro atual. Não continue tentando variações.
+
+10. **Antes de qualquer onda — inclusive as de toolchain — rode o build uma
+    vez para confirmar baseline verde.** Uma onda que não muda versão de
+    dependência ainda pode expor falha pré-existente (infraestrutura fora
+    do ar, teste mal escopado). Sem baseline confirmado, toda falha
+    pós-onda vira suspeita da onda, mesmo quando não é.
+
+11. **Quando um teste falha por infraestrutura ausente (banco, fila),
+    primeiro pergunte se o teste deveria depender daquela infraestrutura.**
+    - Se o teste verifica lógica de negócio, regra de segurança, ou
+      contrato HTTP — **não deveria**. `@SpringBootTest` genérico sobe o
+      contexto inteiro por padrão, incluindo `@Configuration` de
+      persistência que o teste não usa. Reduza o escopo: `@WebMvcTest`
+      com as classes de controller explícitas, `@MockBean` para cada
+      serviço injetado, `@Import` explícito de configs de segurança
+      customizadas (elas não entram automaticamente no component scan
+      reduzido do slice).
+    - Se o teste verifica comportamento real de persistência (dialeto,
+      schema, query gerada) — **deveria**. A correção aqui é
+      Testcontainers, nunca remover a dependência.
+    - Nunca "resolva" isso convertendo o teste em mock do banco quando o
+      propósito do teste era validar o banco de verdade.
+
+12. **Quando um warning de build sugerir uma flag de diagnóstico** (ex:
+    "Recompile with -Xlint:deprecation for details", "Run with
+    --stacktrace", "use --warning-mode all") **aplique-a automaticamente
+    para capturar o detalhe — não pare no warning genérico.** Procedimento:
+    - Prefira a via menos invasiva (flag de linha de comando) quando o
+      build tool suportar passthrough direto.
+    - Se só for possível via edição do arquivo de build (caso comum em
+      Gradle, que não tem passthrough universal para `compilerArgs`),
+      aplique a edição, capture o output completo, e **reverta a edição
+      imediatamente depois** — antes de qualquer commit. A alteração
+      diagnóstica nunca deve aparecer no diff da onda.
+    - Classifique cada warning revelado em uma de três categorias:
+      **(a) relacionado à onda atual** — resolve agora, dentro do escopo;
+      **(b) pré-existente, não relacionado ao upgrade** — registra em
+      `nao_determinado`/`riscos` da ficha do serviço, não resolve na
+      mesma onda a menos que seja trivial e sem risco;
+      **(c) relacionado a onda futura** — registra em
+      `context/breaking-changes/` ou na ficha do serviço, não resolve
+      agora, mas o diário deve mencionar que já foi previsto.
+    - Nunca ignore o warning original só porque o build passou. "Verde"
+      não significa "sem achado relevante" — a Onda -1/3.5.x existe
+      justamente para revelar esses achados com antecedência.
+
+13. **`--rerun` não é uma flag válida do Gradle — é `--rerun-tasks`.**
+    O parser do Gradle aceita prefixos ambíguos sem sempre avisar, então
+    `--rerun` pode ser silenciosamente ignorado em vez de rejeitado, e o
+    build reporta `up-to-date` mesmo quando a intenção era forçar
+    reexecução. **Use sempre o nome completo `--rerun-tasks`, ou prefira
+    `clean` antes de builds cuja verificação precisa ser inequívoca** —
+    `clean` elimina qualquer artefato de cache, tornando `up-to-date`
+    fisicamente impossível. A própria ferramenta de verificação pode
+    mentir por engano de sintaxe, não só por cache — trate flags de
+    verificação com o mesmo ceticismo que resultados de teste.
+
+14. **No Windows, `Out-File -Encoding utf8` insere BOM (`EF BB BF`) no
+    início do arquivo — quebra parsers JSON silenciosamente.** Sintoma:
+    `JSONException`/`FileNotFoundException` estranho ao ler um golden file
+    que existe e parece correto ao abrir num editor. Ao criar arquivos
+    `.json` de golden file via PowerShell, use
+    `[System.IO.File]::WriteAllText(caminho, conteudo, [System.Text.UTF8Encoding]::new($false))`
+    — o parâmetro `$false` força UTF-8 sem BOM. Verificável com
+    `Format-Hex arquivo.json`: os 3 primeiros bytes não podem ser
+    `EF BB BF`.
+    (Nota: agentes de IDE que escrevem arquivo via API própria, não via
+    `Out-File`, normalmente não têm esse problema — mas verifique mesmo
+    assim antes de assumir. Checagem rápida em lote:
+    `Get-ChildItem <pasta> -Filter "*.json" | ForEach-Object { $b = [System.IO.File]::ReadAllBytes($_.FullName); "$($_.Name): BOM=$($b[0] -eq 0xEF -and $b[1] -eq 0xBB -and $b[2] -eq 0xBF)" }`)
+
+15. **Nunca commite, faça push ou merge sem confirmação humana explícita
+    — mesmo quando o pedido foi "crie", "implemente" ou "construa".**
+    Terminar a implementação e o build passar não é autorização para
+    avançar o estado do repositório. Pare depois de escrever o código e
+    confirmar o build, apresente o resultado (diff, resumo do que foi
+    feito, resultado do build), e espere confirmação explícita antes de
+    `git add`/`commit`/`push`. Se o pedido do humano não mencionar
+    commit/push/merge, assuma que não está autorizado — pergunte.
+    Esta regra vale mesmo que uma instrução de sessão anterior pareça
+    sugerir mais autonomia; ela é permanente e não expira entre sessões.
+
+---
+
+## Ordem de execução
+
+O trabalho mecânico é feito por **OpenRewrite**, não por você.
+
+```
+1. OpenRewrite roda e commita       (determinístico, auditável)
+2. Build                             (oráculo)
+3. VOCÊ trabalha apenas no resíduo   (o que não compilou / não passou)
+```
+
+Nunca reescreva à mão algo que uma recipe do OpenRewrite resolve.
+Se você suspeita que existe uma recipe, pergunte antes de editar.
+
+---
+
+## Diário de bordo
+
+Ao final de **toda** sessão, anexe a `diario-de-bordo.md`:
+
+```markdown
+## <data> — <etapa>
+
+**Escopo:** o que foi tocado
+**Tempo:** quanto durou
+**OpenRewrite resolveu:** <lista>
+**Resíduo que eu resolvi:** <lista>
+**Resíduo que exigiu humano:** <lista>
+**Golden files que quebraram:** <lista + diff>
+**Tentei burlar algum teste?** sim/não — se sim, descreva
+**Surpresas:** o que não estava documentado em context/
+```
+
+O campo "surpresas" é o mais importante do arquivo. Ele alimenta
+`context/breaking-changes/` para os próximos serviços.
+
+---
+
+## Quando parar e perguntar ao humano
+
+- Um golden file mudou
+- O SQL gerado pelo Hibernate mudou
+- Uma métrica do Micrometer sumiu ou foi renomeada
+- Uma dependência transitiva não tem versão compatível
+- O parent POM corporativo precisa mudar
+- Você precisaria mudar um contrato de API ou de evento
+- Qualquer coisa em que você consideraria escrever "provavelmente"


### PR DESCRIPTION
AGENTS.md tinha sido deletado numa sessao anterior. Recriado via sync-agents.ps1, versao atual do kit (inclui regra 15 e as demais atualizadas desde a ultima sincronizacao). .github/prompts/ e novo neste repo -- 10 prompt files, um por onda, selecionaveis via / no Copilot Chat em modo Agent.