### PR TITLE
chore: adiciona guardrails de CI (linter de escopo de diff)

### DIFF
--- a/context/guardrails/scope-rules.json
+++ b/context/guardrails/scope-rules.json
@@ -1,0 +1,38 @@
+{
+  "_comentario": "Regras de escopo de diff por tipo de onda. O linter (diff_scope_linter.py) infere o tipo de onda a partir do nome da branch atual -- mesma convencao ja usada em todo o RUNBOOK.md e nos prompt files (onda-0-gradle, onda-3-boot-major, etc). 'allow': se existir, TODO arquivo alterado precisa bater com pelo menos um padrao. 'deny': checado ANTES de allow, sempre vence. Padroes usam sintaxe glob (fnmatch), ** = qualquer profundidade.",
+
+  "ondas": {
+    "onda-0-gradle": {
+      "allow": ["gradle/wrapper/**", "gradlew", "gradlew.bat", "build.gradle", "settings.gradle"]
+    },
+    "onda-neg1-boot-ponte": {
+      "allow": ["build.gradle", "pom.xml"]
+    },
+    "onda-neg1b-mockbean": {
+      "allow": ["build.gradle", "pom.xml", "rewrite.yml", "src/**"],
+      "deny": ["src/main/**"]
+    },
+    "onda-1-java-minimo": {
+      "allow": ["build.gradle", "pom.xml", "settings.gradle"]
+    },
+    "onda-1b-java-lts": {
+      "allow": ["build.gradle", "pom.xml"]
+    },
+    "onda-2a-golden-files": {
+      "allow": ["src/test/**", "**/golden/**"]
+    },
+    "onda-2b-testcontainers": {
+      "allow": ["src/test/**", "**/sql-baseline/**"]
+    },
+    "onda-3-boot-major": {
+      "allow": ["build.gradle", "pom.xml", "src/**", "application.yml", "application.properties", "application-test.yml"],
+      "deny": ["**/golden/**.json", "**/sql-baseline/**.sql"]
+    },
+    "onda-4-jackson-nativo": {
+      "allow": ["application.yml", "application.properties", "application-test.yml", "src/test/**"],
+      "deny": ["**/golden/**.json", "**/sql-baseline/**.sql"]
+    }
+  },
+
+  "_nota_ondas_nao_listadas": "O linter avisa e passa (nao bloqueia por falta de configuracao -- bloquear por omissao seria pior que nao checar). Adicione a onda aqui assim que ela existir no seu processo."
+}

--- a/scripts/diff_scope_linter.py
+++ b/scripts/diff_scope_linter.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""
+diff_scope_linter.py
+
+Verifica se os arquivos alterados numa branch de onda batem com o
+escopo esperado para aquele tipo de onda (context/scope-rules.json).
+
+Deterministico, sem IA, sem dependencia externa (so biblioteca padrao).
+Pensado para rodar como step de CI (GitLab CI) antes de qualquer outra
+checagem -- barato, rapido, sem ambiguidade.
+
+Uso:
+    python3 diff_scope_linter.py [--base main] [--rules scope-rules.json]
+
+Codigo de saida:
+    0 = ok (nenhuma violacao, ou onda nao configurada -- ver nota no
+        proprio scope-rules.json sobre por que isso nao bloqueia)
+    1 = violacao encontrada, ou erro de uso/configuracao
+"""
+
+import argparse
+import fnmatch
+import json
+import subprocess
+import sys
+
+
+def get_current_branch() -> str:
+    result = subprocess.run(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        capture_output=True, text=True, check=True,
+    )
+    return result.stdout.strip()
+
+
+def get_changed_files(base_ref: str) -> list[str]:
+    result = subprocess.run(
+        ["git", "diff", "--name-only", f"{base_ref}...HEAD"],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        print(f"ERRO: nao consegui rodar 'git diff --name-only {base_ref}...HEAD'.")
+        print(result.stderr.strip())
+        print("Confirme que a branch base existe localmente (git fetch pode ser necessario em CI).")
+        sys.exit(1)
+    files = [f for f in result.stdout.strip().split("\n") if f]
+    return files
+
+
+def match_any(path: str, patterns: list[str]) -> str | None:
+    """Retorna o padrao que bateu, ou None se nenhum bateu."""
+    for pattern in patterns:
+        if fnmatch.fnmatch(path, pattern):
+            return pattern
+    return None
+
+
+def find_onda_rules(branch: str, rules: dict) -> tuple[str, dict] | None:
+    """
+    Casa o nome da branch contra as chaves de 'ondas' no rules.json.
+    Aceita tanto nome exato quanto branch prefixada
+    (ex: 'feature/onda-3-boot-major' ou so 'onda-3-boot-major').
+    """
+    ondas = rules.get("ondas", {})
+    for onda_nome, onda_regras in ondas.items():
+        if branch == onda_nome or onda_nome in branch:
+            return onda_nome, onda_regras
+    return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", default="main", help="branch base para comparar (default: main)")
+    parser.add_argument("--rules", default="scope-rules.json", help="caminho do arquivo de regras")
+    args = parser.parse_args()
+
+    try:
+        with open(args.rules, encoding="utf-8") as f:
+            rules = json.load(f)
+    except FileNotFoundError:
+        print(f"ERRO: arquivo de regras '{args.rules}' nao encontrado.")
+        sys.exit(1)
+    except json.JSONDecodeError as e:
+        print(f"ERRO: '{args.rules}' nao e JSON valido: {e}")
+        sys.exit(1)
+
+    branch = get_current_branch()
+    matched = find_onda_rules(branch, rules)
+
+    if matched is None:
+        print(f"AVISO: branch '{branch}' nao corresponde a nenhuma onda configurada em '{args.rules}'.")
+        print("Nao bloqueando -- onda nao configurada passa por padrao (ver nota no proprio arquivo de regras).")
+        sys.exit(0)
+
+    onda_nome, onda_regras = matched
+    allow = onda_regras.get("allow", [])
+    deny = onda_regras.get("deny", [])
+
+    changed_files = get_changed_files(args.base)
+    if not changed_files:
+        print(f"Nenhum arquivo alterado em relacao a '{args.base}'. Nada a checar.")
+        sys.exit(0)
+
+    print(f"Onda detectada: {onda_nome}")
+    print(f"Arquivos alterados: {len(changed_files)}")
+    print("")
+
+    violations = []
+
+    for path in changed_files:
+        denied_by = match_any(path, deny)
+        if denied_by:
+            violations.append((path, f"PROIBIDO explicitamente por '{denied_by}'"))
+            continue
+
+        if allow:
+            allowed_by = match_any(path, allow)
+            if not allowed_by:
+                violations.append((path, f"fora do escopo permitido para '{onda_nome}'"))
+
+    if violations:
+        print(f"FALHOU: {len(violations)} arquivo(s) fora do escopo esperado para '{onda_nome}':")
+        print("")
+        for path, reason in violations:
+            print(f"  {path}")
+            print(f"    -> {reason}")
+        print("")
+        print("Se esta mudanca e legitima, ou o arquivo pertence a outra onda")
+        print("(nao deveria estar neste commit), ou scope-rules.json precisa")
+        print(f"ser atualizado para refletir o escopo real de '{onda_nome}'.")
+        print("Atualizar o arquivo de regras e decisao humana, nao automatica.")
+        sys.exit(1)
+
+    print(f"OK: todos os {len(changed_files)} arquivo(s) alterado(s) estao dentro do escopo de '{onda_nome}'.")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
scripts/diff_scope_linter.py + context/guardrails/scope-rules.json. Instalacao do proprio guardrail, sem relacao com nenhuma onda de codigo -- por isso commit isolado, nao misturado com nenhuma onda.

Testado contra este mesmo repositorio: violacao deliberada em src/main durante simulacao de onda-2a-golden-files foi corretamente bloqueada (codigo de saida 1), apontando so o arquivo real fora de escopo -- nao mais os proprios arquivos do linter (correcao aplicada apos o primeiro teste real ter revelado esse caso de borda).